### PR TITLE
Feat: 에러메시지를 활용한 예외 처리 기능 추가

### DIFF
--- a/src/main/java/com/todo/todoapp/application/todo/TodoService.java
+++ b/src/main/java/com/todo/todoapp/application/todo/TodoService.java
@@ -2,6 +2,9 @@ package com.todo.todoapp.application.todo;
 
 import com.todo.todoapp.domain.todo.model.Todo;
 import com.todo.todoapp.domain.todo.repository.TodoRepository;
+import com.todo.todoapp.global.exception.todo.IncorrectPasswordException;
+import com.todo.todoapp.global.exception.todo.NoSuchTodoException;
+import com.todo.todoapp.global.exception.todo.code.TodoErrorCode;
 import com.todo.todoapp.presentation.todo.dto.request.CreateTodoRequest;
 import com.todo.todoapp.presentation.todo.dto.request.DeleteTodoRequest;
 import com.todo.todoapp.presentation.todo.dto.request.UpdateTodoRequest;
@@ -52,14 +55,12 @@ public class TodoService {
     }
 
     private Todo getTodoById(long id) {
-        Todo todo = todoRepository.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException(id + "로 조회되는 할 일은 없습니다"));
-        return todo;
+        return todoRepository.findById(id).orElseThrow(() -> new NoSuchTodoException(TodoErrorCode.FIND_FAILED));
     }
 
     private void isCorrectPassword(String origin, String comparison) {
         if (!origin.equals(comparison)) {
-            throw new IllegalArgumentException("비밀번호가 올바르지 않습니다.");
+            throw new IncorrectPasswordException(TodoErrorCode.INCORRECT_PASSWORD);
         }
     }
 }

--- a/src/main/java/com/todo/todoapp/global/exception/common/CustomException.java
+++ b/src/main/java/com/todo/todoapp/global/exception/common/CustomException.java
@@ -1,0 +1,11 @@
+package com.todo.todoapp.global.exception.common;
+
+import com.todo.todoapp.global.exception.common.code.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ErrorCode errorCode;
+}

--- a/src/main/java/com/todo/todoapp/global/exception/common/code/CommonErrorCode.java
+++ b/src/main/java/com/todo/todoapp/global/exception/common/code/CommonErrorCode.java
@@ -1,0 +1,34 @@
+package com.todo.todoapp.global.exception.common.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CommonErrorCode implements ErrorCode {
+    INVALID_ARGS(HttpStatus.BAD_REQUEST, "유효성 검증 실패. 양식에 맞는 값이 아닙니다.");
+
+    private HttpStatus httpStatus;
+    private String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public void setHttpStatus(HttpStatus httpStatus) {
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/exception/common/code/CommonErrorCode.java
+++ b/src/main/java/com/todo/todoapp/global/exception/common/code/CommonErrorCode.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @AllArgsConstructor
 public enum CommonErrorCode implements ErrorCode {
-    INVALID_ARGS(HttpStatus.BAD_REQUEST, "유효성 검증 실패. 양식에 맞는 값이 아닙니다.");
+    INVALID_ARGS(HttpStatus.BAD_REQUEST, "유효성 검증 실패. 양식에 맞는 값이 아닙니다."),
+    UNKNOWN_ERR(HttpStatus.INTERNAL_SERVER_ERROR, "알 수 없는 에러가 발생했습니다."),
+    ;
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/todo/todoapp/global/exception/common/code/ErrorCode.java
+++ b/src/main/java/com/todo/todoapp/global/exception/common/code/ErrorCode.java
@@ -1,0 +1,13 @@
+package com.todo.todoapp.global.exception.common.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface ErrorCode {
+    HttpStatus getHttpStatus();
+
+    void setHttpStatus(HttpStatus httpStatus);
+
+    String getMessage();
+
+    void setMessage(String message);
+}

--- a/src/main/java/com/todo/todoapp/global/exception/handler/RestApiExceptionHandler.java
+++ b/src/main/java/com/todo/todoapp/global/exception/handler/RestApiExceptionHandler.java
@@ -1,8 +1,40 @@
 package com.todo.todoapp.global.exception.handler;
 
+import com.todo.todoapp.global.exception.common.CustomException;
+import com.todo.todoapp.global.exception.common.code.CommonErrorCode;
+import com.todo.todoapp.global.exception.handler.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class RestApiExceptionHandler {
 
+    // @Valid 처리
+    @ExceptionHandler
+    protected ResponseEntity<ErrorResponse> handleInvalidArgumentException(MethodArgumentNotValidException exception) {
+        logInfo(exception);
+        return ErrorResponse.of(CommonErrorCode.INVALID_ARGS, exception.getBindingResult());
+    }
+
+    // 사용자 정의 예외 처리
+    @ExceptionHandler
+    ResponseEntity<ErrorResponse> handleCustomException(CustomException exception) {
+        logInfo(exception);
+        return ErrorResponse.of(exception.getErrorCode());
+    }
+
+    // 그 외 런타임 예외
+    @ExceptionHandler
+    ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException exception) {
+        logInfo(exception);
+        return ErrorResponse.of(CommonErrorCode.UNKNOWN_ERR);
+    }
+
+    private void logInfo(Exception exception) {
+        log.info(exception.getStackTrace().toString());
+    }
 }

--- a/src/main/java/com/todo/todoapp/global/exception/handler/RestApiExceptionHandler.java
+++ b/src/main/java/com/todo/todoapp/global/exception/handler/RestApiExceptionHandler.java
@@ -1,0 +1,8 @@
+package com.todo.todoapp.global.exception.handler;
+
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class RestApiExceptionHandler {
+
+}

--- a/src/main/java/com/todo/todoapp/global/exception/handler/response/ErrorResponse.java
+++ b/src/main/java/com/todo/todoapp/global/exception/handler/response/ErrorResponse.java
@@ -1,0 +1,53 @@
+package com.todo.todoapp.global.exception.handler.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import jakarta.annotation.Nullable;
+import lombok.Builder;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+@Builder
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ErrorResponse(
+        HttpStatus httpStatus,
+        String message,
+        @Nullable
+        List<ValidError> validError
+) {
+    @Builder
+    record ValidError(
+            String field,
+            String value,
+            String message
+    ) {
+
+        static List<ValidError> of(BindingResult bindingResult) {
+            List<FieldError> errors = bindingResult.getFieldErrors();
+
+            return errors.stream().map((error) -> ValidError.builder()
+                    .field(error.getField())
+                    .value(String.valueOf(error.getRejectedValue()))
+                    .message(error.getDefaultMessage())
+                    .build()
+            ).toList();
+        }
+    }
+
+    static ErrorResponse of(HttpStatus httpStatus, String message) {
+        return ErrorResponse.builder()
+                .httpStatus(httpStatus)
+                .message(message)
+                .build();
+    }
+
+    static ErrorResponse of(HttpStatus httpStatus, String message, BindingResult bindingResult) {
+        return ErrorResponse.builder()
+                .httpStatus(httpStatus)
+                .message(message)
+                .validError(ValidError.of(bindingResult))
+                .build();
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/exception/handler/response/ErrorResponse.java
+++ b/src/main/java/com/todo/todoapp/global/exception/handler/response/ErrorResponse.java
@@ -1,9 +1,10 @@
 package com.todo.todoapp.global.exception.handler.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.todo.todoapp.global.exception.common.code.ErrorCode;
 import jakarta.annotation.Nullable;
 import lombok.Builder;
-import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 
@@ -12,8 +13,7 @@ import java.util.List;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ErrorResponse(
-        HttpStatus httpStatus,
-        String message,
+        ErrorCode errorCode,
         @Nullable
         List<ValidError> validError
 ) {
@@ -36,18 +36,18 @@ public record ErrorResponse(
         }
     }
 
-    public static ErrorResponse of(HttpStatus httpStatus, String message) {
-        return ErrorResponse.builder()
-                .httpStatus(httpStatus)
-                .message(message)
-                .build();
+    public static ResponseEntity<ErrorResponse> of(ErrorCode errorCode) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(ErrorResponse.builder()
+                        .errorCode(errorCode)
+                        .build());
     }
 
-    public static ErrorResponse of(HttpStatus httpStatus, String message, BindingResult bindingResult) {
-        return ErrorResponse.builder()
-                .httpStatus(httpStatus)
-                .message(message)
-                .validError(ValidError.of(bindingResult))
-                .build();
+    public static ResponseEntity<ErrorResponse> of(ErrorCode errorCode, BindingResult bindingResult) {
+        return ResponseEntity.status(errorCode.getHttpStatus())
+                .body(ErrorResponse.builder()
+                        .errorCode(errorCode)
+                        .validError(ValidError.of(bindingResult))
+                        .build());
     }
 }

--- a/src/main/java/com/todo/todoapp/global/exception/handler/response/ErrorResponse.java
+++ b/src/main/java/com/todo/todoapp/global/exception/handler/response/ErrorResponse.java
@@ -18,13 +18,13 @@ public record ErrorResponse(
         List<ValidError> validError
 ) {
     @Builder
-    record ValidError(
+    private record ValidError(
             String field,
             String value,
             String message
     ) {
 
-        static List<ValidError> of(BindingResult bindingResult) {
+        private static List<ValidError> of(BindingResult bindingResult) {
             List<FieldError> errors = bindingResult.getFieldErrors();
 
             return errors.stream().map((error) -> ValidError.builder()
@@ -36,14 +36,14 @@ public record ErrorResponse(
         }
     }
 
-    static ErrorResponse of(HttpStatus httpStatus, String message) {
+    public static ErrorResponse of(HttpStatus httpStatus, String message) {
         return ErrorResponse.builder()
                 .httpStatus(httpStatus)
                 .message(message)
                 .build();
     }
 
-    static ErrorResponse of(HttpStatus httpStatus, String message, BindingResult bindingResult) {
+    public static ErrorResponse of(HttpStatus httpStatus, String message, BindingResult bindingResult) {
         return ErrorResponse.builder()
                 .httpStatus(httpStatus)
                 .message(message)

--- a/src/main/java/com/todo/todoapp/global/exception/todo/IncorrectPasswordException.java
+++ b/src/main/java/com/todo/todoapp/global/exception/todo/IncorrectPasswordException.java
@@ -1,0 +1,8 @@
+package com.todo.todoapp.global.exception.todo;
+
+import com.todo.todoapp.global.exception.common.CustomException;
+import com.todo.todoapp.global.exception.common.code.ErrorCode;
+
+public class IncorrectPasswordException extends CustomException {
+    public IncorrectPasswordException(ErrorCode errorCode) { super(errorCode); }
+}

--- a/src/main/java/com/todo/todoapp/global/exception/todo/NoSuchTodoException.java
+++ b/src/main/java/com/todo/todoapp/global/exception/todo/NoSuchTodoException.java
@@ -1,0 +1,10 @@
+package com.todo.todoapp.global.exception.todo;
+
+import com.todo.todoapp.global.exception.common.CustomException;
+import com.todo.todoapp.global.exception.common.code.ErrorCode;
+
+public class NoSuchTodoException extends CustomException {
+    public NoSuchTodoException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/exception/todo/code/TodoErrorCode.java
+++ b/src/main/java/com/todo/todoapp/global/exception/todo/code/TodoErrorCode.java
@@ -11,10 +11,8 @@ public enum TodoErrorCode implements ErrorCode {
 
     // 수정 / 삭제 시, 비밀번호가 일치하지 않을 때
     INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
-    // 선택한 일정 정보가 이미 삭제되어 조회할 수 없을 때
-    FIND_FAILED(HttpStatus.NO_CONTENT, "선택하신 일정은 조회할 수 없습니다."),
-    // 삭제하려는 일정 정보가 이미 삭제 상태일 때
-    ALREADY_DELETED(HttpStatus.NOT_FOUND, "해당 일정은 존재하지 않거나 이미 삭제되었습니다.");
+    // 일정이 존재하지 않거나 이미 삭제 되었을 때
+    FIND_FAILED(HttpStatus.NO_CONTENT, "해당 일정은 존재하지 않거나 이미 삭제되었습니다."),
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/todo/todoapp/global/exception/todo/code/TodoErrorCode.java
+++ b/src/main/java/com/todo/todoapp/global/exception/todo/code/TodoErrorCode.java
@@ -1,0 +1,41 @@
+package com.todo.todoapp.global.exception.todo.code;
+
+import com.todo.todoapp.global.exception.common.code.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum TodoErrorCode implements ErrorCode {
+
+    // 수정 / 삭제 시, 비밀번호가 일치하지 않을 때
+    INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
+    // 선택한 일정 정보가 이미 삭제되어 조회할 수 없을 때
+    FIND_FAILED(HttpStatus.NO_CONTENT, "선택하신 일정은 조회할 수 없습니다."),
+    // 삭제하려는 일정 정보가 이미 삭제 상태일 때
+    ALREADY_DELETED(HttpStatus.NOT_FOUND, "해당 일정은 존재하지 않거나 이미 삭제되었습니다.");
+
+    private HttpStatus httpStatus;
+    private String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public void setHttpStatus(HttpStatus httpStatus) {
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/exception/todo/code/TodoErrorCode.java
+++ b/src/main/java/com/todo/todoapp/global/exception/todo/code/TodoErrorCode.java
@@ -13,7 +13,7 @@ public enum TodoErrorCode implements ErrorCode {
     INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     // 일정이 존재하지 않거나 이미 삭제 되었을 때
     FIND_FAILED(HttpStatus.NO_CONTENT, "해당 일정은 존재하지 않거나 이미 삭제되었습니다."),
-
+    ;
     private HttpStatus httpStatus;
     private String message;
 

--- a/src/main/java/com/todo/todoapp/presentation/todo/TodoController.java
+++ b/src/main/java/com/todo/todoapp/presentation/todo/TodoController.java
@@ -5,6 +5,7 @@ import com.todo.todoapp.presentation.todo.dto.request.CreateTodoRequest;
 import com.todo.todoapp.presentation.todo.dto.request.DeleteTodoRequest;
 import com.todo.todoapp.presentation.todo.dto.request.UpdateTodoRequest;
 import com.todo.todoapp.presentation.todo.dto.response.TodoResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -20,7 +21,7 @@ public class TodoController {
     private final TodoService todoService;
 
     @PostMapping
-    public ResponseEntity<TodoResponse> save(@RequestBody CreateTodoRequest request) {
+    public ResponseEntity<TodoResponse> save(@Valid @RequestBody CreateTodoRequest request) {
         TodoResponse response = todoService.save(request);
         long id = response.id();
         URI uri = URI.create(String.format("/todos/%d", id));
@@ -40,13 +41,17 @@ public class TodoController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<TodoResponse> update(@PathVariable long id, @RequestBody UpdateTodoRequest request) {
+    public ResponseEntity<TodoResponse> update(
+            @PathVariable long id,
+            @Valid @RequestBody UpdateTodoRequest request) {
         TodoResponse response = todoService.update(id, request);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable long id, @RequestBody DeleteTodoRequest request) {
+    public ResponseEntity<Void> delete(
+            @PathVariable long id,
+            @Valid @RequestBody DeleteTodoRequest request) {
         todoService.delete(id, request);
         return ResponseEntity.noContent().build();
     }


### PR DESCRIPTION
# 관련 이슈
- close #14 

# 작업
- @RestControllerAdvice를 통한 전역 예외 처리 기능을 추가했다.
- 예외 처리 핸들링 메서드에 공통적으로 사용될 ErrorResponse를 작성하고, 해당 클래스의 HttpStatusCode와 Message를 가지고 있는 ErrorCode를 작성했다.
- 사용자 정의 예외 클래스에 공통적으로 ErrorCode를 필드로 가지기 위한 상위 클래스 CustomException을 추가했다.
- Controller에 @Valid를 추가하여 MethodArgumentNotValidException을 처리할 수 있게 하였다.
- Service에 새롭게 생성한 사용자 정의 예외를 던지게 끔 로직을 수정하였다.

# 고민
- ErrorCode를 인터페이스로 구현했는데(Enum은 클래스라 다중 상속이 불가능하기 때문이다.) getter와 setter를 롬복으로 처리할 수 없는지 고민이다.
  - 일단 내가 직접 Getter/Setter를 만들고 구현체 클래스에서 하나씩 Overriding 하긴 했는데 이게 맞는지 모르겠다.