### PR TITLE
Feat: 댓글 엔티티 추가 및 연관관계 설정

### DIFF
--- a/src/main/java/com/todo/todoapp/application/todo/TodoService.java
+++ b/src/main/java/com/todo/todoapp/application/todo/TodoService.java
@@ -34,7 +34,7 @@ public class TodoService {
 
     public List<TodoResponse> findAll() {
         List<Todo> todos = todoRepository.findAll();
-        todos.sort(Comparator.comparing(Todo::getCreatedDate).reversed());
+        todos.sort(Comparator.comparing(Todo::getCreatedAt).reversed());
         return todos.stream().map((TodoResponse::from)).toList();
     }
 

--- a/src/main/java/com/todo/todoapp/domain/comment/model/Comment.java
+++ b/src/main/java/com/todo/todoapp/domain/comment/model/Comment.java
@@ -1,0 +1,27 @@
+package com.todo.todoapp.domain.comment.model;
+
+import com.todo.todoapp.domain.todo.model.Todo;
+import com.todo.todoapp.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@Entity(name = "comments")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Comment extends BaseEntity {
+
+    @Id
+    @Column(name = "comment_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @ManyToOne
+    @JoinColumn(name = "todo_id")
+    private Todo todo;
+
+    private String comment;
+
+    private String writer;
+}

--- a/src/main/java/com/todo/todoapp/domain/todo/model/Todo.java
+++ b/src/main/java/com/todo/todoapp/domain/todo/model/Todo.java
@@ -1,25 +1,22 @@
 package com.todo.todoapp.domain.todo.model;
 
+import com.todo.todoapp.global.entity.BaseEntity;
 import com.todo.todoapp.presentation.todo.dto.request.UpdateTodoRequest;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Getter
 @Entity(name = "todos")
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class Todo {
+public class Todo extends BaseEntity {
 
     @Id
+    @Column(name = "todo_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
@@ -27,7 +24,6 @@ public class Todo {
     private String description;
     private String manager;
     private String password;
-    private LocalDateTime createdDate;
 
     public void update(UpdateTodoRequest request) {
         this.title = request.title();

--- a/src/main/java/com/todo/todoapp/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/todo/todoapp/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.todo.todoapp.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/todo/todoapp/global/entity/BaseEntity.java
+++ b/src/main/java/com/todo/todoapp/global/entity/BaseEntity.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @Getter
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
-public class BaseEntity {
+public abstract class BaseEntity {
 
     @Column(columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
     @CreatedDate

--- a/src/main/java/com/todo/todoapp/global/entity/BaseEntity.java
+++ b/src/main/java/com/todo/todoapp/global/entity/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.todo.todoapp.global.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseEntity {
+
+    @Column(columnDefinition = "TIMESTAMP(6)", nullable = false, updatable = false)
+    @CreatedDate
+    private LocalDateTime createdAt;
+
+    @Column(columnDefinition = "TIMESTAMP(6)", nullable = false)
+    @CreatedDate
+    private LocalDateTime updatedAt;
+}
+

--- a/src/main/java/com/todo/todoapp/presentation/todo/dto/request/CreateTodoRequest.java
+++ b/src/main/java/com/todo/todoapp/presentation/todo/dto/request/CreateTodoRequest.java
@@ -4,10 +4,6 @@ import com.todo.todoapp.domain.todo.model.Todo;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.Builder;
-
-import java.time.LocalDateTime;
-import java.util.Objects;
 
 public record CreateTodoRequest(
 
@@ -22,25 +18,14 @@ public record CreateTodoRequest(
         String manager,
         @NotBlank(message = "비밀번호는 필수 입력입니다.(4글자)")
         @Size(min = 4, max = 4)
-        String password,
-
-        LocalDateTime createdDate
+        String password
 ) {
-
-    @Builder
-    public CreateTodoRequest {
-        if (Objects.isNull(createdDate)) {
-            createdDate = LocalDateTime.now();
-        }
-    }
-
     public Todo toEntity() {
         return Todo.builder()
                 .title(title)
                 .description(description)
                 .manager(manager)
                 .password(password)
-                .createdDate(createdDate)
                 .build();
     }
 }

--- a/src/main/java/com/todo/todoapp/presentation/todo/dto/response/TodoResponse.java
+++ b/src/main/java/com/todo/todoapp/presentation/todo/dto/response/TodoResponse.java
@@ -10,7 +10,7 @@ public record TodoResponse(
         long id,
         String title,
         String description,
-        LocalDateTime createdDate,
+        LocalDateTime createdAt,
         String manager
 ) {
     public static TodoResponse from(Todo todo) {
@@ -19,7 +19,7 @@ public record TodoResponse(
                 .title(todo.getTitle())
                 .description(todo.getDescription())
                 .manager(todo.getManager())
-                .createdDate(todo.getCreatedDate())
+                .createdAt(todo.getCreatedAt())
                 .build();
     }
 }


### PR DESCRIPTION
# 관련 이슈
- close #21 

# 작업
- Todo 엔티티와 Comment 엔티티에 필드 createdAt이 겹쳐서 추상화 부모 엔티티 BaseEntity를 적용했다.
- AuditingListener 적용을 위한 JpaAuditingConfig 클래스를 생성했다.
- Comment 엔티티를 생성하고, Todo 엔티티와 연관관계를 N:1 단방향으로 설정했다.
