### PR TITLE
Feat: 댓글 생성 기능 추가

### DIFF
--- a/src/main/java/com/todo/todoapp/application/comment/CommentService.java
+++ b/src/main/java/com/todo/todoapp/application/comment/CommentService.java
@@ -1,0 +1,30 @@
+package com.todo.todoapp.application.comment;
+
+import com.todo.todoapp.domain.comment.model.Comment;
+import com.todo.todoapp.domain.todo.model.Todo;
+import com.todo.todoapp.domain.todo.repository.TodoRepository;
+import com.todo.todoapp.global.exception.todo.NoSuchTodoException;
+import com.todo.todoapp.global.exception.todo.code.TodoErrorCode;
+import com.todo.todoapp.presentation.comment.dto.request.CreateCommentRequest;
+import com.todo.todoapp.presentation.comment.dto.response.CommentResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+
+    private final TodoRepository todoRepository;
+    private final CommentRepository commentRepository;
+
+    public CommentResponse save(long todoId, CreateCommentRequest request) {
+        Todo todo = getTodoById(todoId);
+        Comment comment = commentRepository.save(request.toEntity(todo));
+
+        return CommentResponse.from(comment);
+    }
+
+    private Todo getTodoById(long todoId) {
+        return todoRepository.findById(todoId).orElseThrow(() -> new NoSuchTodoException(TodoErrorCode.FIND_FAILED));
+    }
+}

--- a/src/main/java/com/todo/todoapp/application/comment/CommentService.java
+++ b/src/main/java/com/todo/todoapp/application/comment/CommentService.java
@@ -1,6 +1,7 @@
 package com.todo.todoapp.application.comment;
 
 import com.todo.todoapp.domain.comment.model.Comment;
+import com.todo.todoapp.domain.comment.repository.CommentRepository;
 import com.todo.todoapp.domain.todo.model.Todo;
 import com.todo.todoapp.domain.todo.repository.TodoRepository;
 import com.todo.todoapp.global.exception.todo.NoSuchTodoException;

--- a/src/main/java/com/todo/todoapp/domain/comment/model/Comment.java
+++ b/src/main/java/com/todo/todoapp/domain/comment/model/Comment.java
@@ -23,5 +23,5 @@ public class Comment extends BaseEntity {
 
     private String comment;
 
-    private String writer;
+    private String writerId;
 }

--- a/src/main/java/com/todo/todoapp/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/todo/todoapp/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package com.todo.todoapp.domain.comment.repository;
+
+import com.todo.todoapp.domain.comment.model.Comment;
+
+public interface CommentRepository {
+    Comment save(Comment comment);
+}

--- a/src/main/java/com/todo/todoapp/global/exception/common/CustomException.java
+++ b/src/main/java/com/todo/todoapp/global/exception/common/CustomException.java
@@ -6,6 +6,6 @@ import lombok.Getter;
 
 @Getter
 @AllArgsConstructor
-public class CustomException extends RuntimeException {
+public abstract class CustomException extends RuntimeException {
     private final ErrorCode errorCode;
 }

--- a/src/main/java/com/todo/todoapp/global/exception/handler/RestApiExceptionHandler.java
+++ b/src/main/java/com/todo/todoapp/global/exception/handler/RestApiExceptionHandler.java
@@ -35,6 +35,6 @@ public class RestApiExceptionHandler {
     }
 
     private void logInfo(Exception exception) {
-        log.info(exception.getStackTrace().toString());
+        log.info(exception.getMessage());
     }
 }

--- a/src/main/java/com/todo/todoapp/global/exception/handler/response/ErrorResponse.java
+++ b/src/main/java/com/todo/todoapp/global/exception/handler/response/ErrorResponse.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.todo.todoapp.global.exception.common.code.ErrorCode;
 import jakarta.annotation.Nullable;
 import lombok.Builder;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
@@ -13,7 +14,8 @@ import java.util.List;
 @Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public record ErrorResponse(
-        ErrorCode errorCode,
+        HttpStatus httpStatus,
+        String message,
         @Nullable
         List<ValidError> validError
 ) {
@@ -39,14 +41,16 @@ public record ErrorResponse(
     public static ResponseEntity<ErrorResponse> of(ErrorCode errorCode) {
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(ErrorResponse.builder()
-                        .errorCode(errorCode)
+                        .httpStatus(errorCode.getHttpStatus())
+                        .message(errorCode.getMessage())
                         .build());
     }
 
     public static ResponseEntity<ErrorResponse> of(ErrorCode errorCode, BindingResult bindingResult) {
         return ResponseEntity.status(errorCode.getHttpStatus())
                 .body(ErrorResponse.builder()
-                        .errorCode(errorCode)
+                        .httpStatus(errorCode.getHttpStatus())
+                        .message(errorCode.getMessage())
                         .validError(ValidError.of(bindingResult))
                         .build());
     }

--- a/src/main/java/com/todo/todoapp/global/exception/todo/code/TodoErrorCode.java
+++ b/src/main/java/com/todo/todoapp/global/exception/todo/code/TodoErrorCode.java
@@ -12,7 +12,7 @@ public enum TodoErrorCode implements ErrorCode {
     // 수정 / 삭제 시, 비밀번호가 일치하지 않을 때
     INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "비밀번호가 일치하지 않습니다."),
     // 일정이 존재하지 않거나 이미 삭제 되었을 때
-    FIND_FAILED(HttpStatus.NO_CONTENT, "해당 일정은 존재하지 않거나 이미 삭제되었습니다."),
+    FIND_FAILED(HttpStatus.BAD_REQUEST, "해당 일정은 존재하지 않거나 이미 삭제되었습니다."),
     ;
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/todo/todoapp/infrastructure/comment/CommentRepositoryImpl.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/comment/CommentRepositoryImpl.java
@@ -1,0 +1,18 @@
+package com.todo.todoapp.infrastructure.comment;
+
+import com.todo.todoapp.domain.comment.model.Comment;
+import com.todo.todoapp.domain.comment.repository.CommentRepository;
+import com.todo.todoapp.infrastructure.comment.hibernate.CommentJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class CommentRepositoryImpl implements CommentRepository {
+    private final CommentJpaRepository jpaRepository;
+
+    @Override
+    public Comment save(Comment comment) {
+        return jpaRepository.save(comment);
+    }
+}

--- a/src/main/java/com/todo/todoapp/infrastructure/comment/hibernate/CommentJpaRepository.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/comment/hibernate/CommentJpaRepository.java
@@ -1,0 +1,7 @@
+package com.todo.todoapp.infrastructure.comment.hibernate;
+
+import com.todo.todoapp.domain.comment.model.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentJpaRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
@@ -1,11 +1,30 @@
 package com.todo.todoapp.presentation.comment;
 
+import com.todo.todoapp.application.comment.CommentService;
+import com.todo.todoapp.presentation.comment.dto.request.CreateCommentRequest;
+import com.todo.todoapp.presentation.comment.dto.response.CommentResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
 
 @RestController
 @RequestMapping("/comments")
 @RequiredArgsConstructor
 public class CommentController {
+
+    private final CommentService commentService;
+
+    @PostMapping("/{todoId}")
+    public ResponseEntity<CommentResponse> save(
+            @PathVariable long todoId,
+            @Valid @RequestBody CreateCommentRequest request) {
+        CommentResponse response = commentService.save(request);
+        long id = response.id();
+        URI uri = URI.create(String.format("/comments/%d/%d", todoId, id));
+        return ResponseEntity.created(uri).body(response);
+    }
+
 }

--- a/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
@@ -21,7 +21,7 @@ public class CommentController {
     public ResponseEntity<CommentResponse> save(
             @PathVariable long todoId,
             @Valid @RequestBody CreateCommentRequest request) {
-        CommentResponse response = commentService.save(request);
+        CommentResponse response = commentService.save(todoId, request);
         long id = response.id();
         URI uri = URI.create(String.format("/comments/%d/%d", todoId, id));
         return ResponseEntity.created(uri).body(response);

--- a/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
@@ -1,0 +1,11 @@
+package com.todo.todoapp.presentation.comment;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/comments")
+@RequiredArgsConstructor
+public class CommentController {
+}

--- a/src/main/java/com/todo/todoapp/presentation/comment/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/dto/request/CreateCommentRequest.java
@@ -1,0 +1,12 @@
+package com.todo.todoapp.presentation.comment.dto.request;
+
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateCommentRequest(
+        @NotBlank(message = "내용을 입력해주세요")
+        String description,
+        @NotBlank(message = "댓글 작성자의 ID를 입력해주세요")
+        String writerId
+) {
+}

--- a/src/main/java/com/todo/todoapp/presentation/comment/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/dto/request/CreateCommentRequest.java
@@ -1,12 +1,21 @@
 package com.todo.todoapp.presentation.comment.dto.request;
 
 
+import com.todo.todoapp.domain.comment.model.Comment;
+import com.todo.todoapp.domain.todo.model.Todo;
 import jakarta.validation.constraints.NotBlank;
 
 public record CreateCommentRequest(
         @NotBlank(message = "내용을 입력해주세요")
-        String description,
+        String comment,
         @NotBlank(message = "댓글 작성자의 ID를 입력해주세요")
         String writerId
 ) {
+    public Comment toEntity(Todo todo) {
+        return Comment.builder()
+                .comment(comment)
+                .writerId(writerId)
+                .todo(todo)
+                .build();
+    }
 }

--- a/src/main/java/com/todo/todoapp/presentation/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/dto/response/CommentResponse.java
@@ -14,6 +14,7 @@ public record CommentResponse(
 ) {
     public static CommentResponse from(Comment comment) {
         return CommentResponse.builder()
+                .id(comment.getId())
                 .comment(comment.getComment())
                 .writerId(comment.getWriterId())
                 .createdAt(comment.getCreatedAt())

--- a/src/main/java/com/todo/todoapp/presentation/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/dto/response/CommentResponse.java
@@ -1,12 +1,23 @@
 package com.todo.todoapp.presentation.comment.dto.response;
 
+import com.todo.todoapp.domain.comment.model.Comment;
 import lombok.Builder;
+
+import java.time.LocalDateTime;
 
 @Builder
 public record CommentResponse(
         long id,
-        String description,
-        String writer,
-        String createdAt
+        String comment,
+        String writerId,
+        LocalDateTime createdAt
 ) {
+    public static CommentResponse from(Comment comment) {
+        return CommentResponse.builder()
+                .comment(comment.getComment())
+                .writerId(comment.getWriterId())
+                .createdAt(comment.getCreatedAt())
+                .build();
+
+    }
 }

--- a/src/main/java/com/todo/todoapp/presentation/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/dto/response/CommentResponse.java
@@ -1,0 +1,12 @@
+package com.todo.todoapp.presentation.comment.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CommentResponse(
+        long id,
+        String description,
+        String writer,
+        String createdAt
+) {
+}


### PR DESCRIPTION
# 관련 이슈
- closes #21 
- closes #22 

# 작업
- Controller / Service / Repository 댓글 작성 기능을 작성했다.
- Comment 생성을 위한 Request DTO와 클라이언트 Response DTO를 작성했다.
- CommentResponse(DTO)에서 id 필드가 누락되어 있어, 이를 수정했다.
- 예외 처리를 꽤 크게 수정했다.
  - CustomException 'abstract' 키워드 추가
  - RestApiExceptionHandler logInfo() 메서드 수정
  - TodoErrorCode HttpStatusCode 수정(204 -> 400)
  - ErrorResponse 필드 변경 및 팩토리 메서드 변경

# 트러블 슈팅
- HttpStatus의 NO CONENT는 Body가 존재하지 않는다.
  - 처음에 생각없이 개발하다가 Entity를 찾지 못했을 때 ResponseEntity의 statusCode를 NO_CONTENT(204)로 두고, Body에 내가 직접 생성한 ErrorResponse(Record Class)를 넣었다.
  - 그래서 Postman으로 예외 처리에 대한 올바른 응답값이 오지 않을 뿐더러 아무런 반환값이 날아오지 않게 되었다.
  - 이를 Bad Request(400)으로 수정하니 해결 되었다.
  - HttpStatus No Content(204)에는 Body가 존재하지 않는 것을 명심하자.