### PR TITLE
Feat: 댓글 수정 기능 구현

### DIFF
--- a/src/main/java/com/todo/todoapp/application/comment/CommentService.java
+++ b/src/main/java/com/todo/todoapp/application/comment/CommentService.java
@@ -4,6 +4,8 @@ import com.todo.todoapp.domain.comment.model.Comment;
 import com.todo.todoapp.domain.comment.repository.CommentRepository;
 import com.todo.todoapp.domain.todo.model.Todo;
 import com.todo.todoapp.domain.todo.repository.TodoRepository;
+import com.todo.todoapp.global.exception.comment.NoSuchCommentException;
+import com.todo.todoapp.global.exception.comment.code.CommentErrorCode;
 import com.todo.todoapp.global.exception.todo.NoSuchTodoException;
 import com.todo.todoapp.global.exception.todo.code.TodoErrorCode;
 import com.todo.todoapp.presentation.comment.dto.request.CreateCommentRequest;

--- a/src/main/java/com/todo/todoapp/application/comment/CommentService.java
+++ b/src/main/java/com/todo/todoapp/application/comment/CommentService.java
@@ -7,7 +7,9 @@ import com.todo.todoapp.domain.todo.repository.TodoRepository;
 import com.todo.todoapp.global.exception.todo.NoSuchTodoException;
 import com.todo.todoapp.global.exception.todo.code.TodoErrorCode;
 import com.todo.todoapp.presentation.comment.dto.request.CreateCommentRequest;
+import com.todo.todoapp.presentation.comment.dto.request.UpdateCommentRequest;
 import com.todo.todoapp.presentation.comment.dto.response.CommentResponse;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +20,7 @@ public class CommentService {
     private final TodoRepository todoRepository;
     private final CommentRepository commentRepository;
 
+    @Transactional
     public CommentResponse save(long todoId, CreateCommentRequest request) {
         Todo todo = getTodoById(todoId);
         Comment comment = commentRepository.save(request.toEntity(todo));
@@ -27,5 +30,16 @@ public class CommentService {
 
     private Todo getTodoById(long todoId) {
         return todoRepository.findById(todoId).orElseThrow(() -> new NoSuchTodoException(TodoErrorCode.FIND_FAILED));
+    }
+
+    @Transactional
+    public CommentResponse update(long id, UpdateCommentRequest request) {
+        Comment comment = getCommentById(id);
+        comment.update(request);
+        return CommentResponse.from(comment);
+    }
+
+    private Comment getCommentById(long id) {
+        return commentRepository.findById(id).orElseThrow(() -> new NoSuchCommentException(CommentErrorCode.FIND_FAILED));
     }
 }

--- a/src/main/java/com/todo/todoapp/domain/comment/model/Comment.java
+++ b/src/main/java/com/todo/todoapp/domain/comment/model/Comment.java
@@ -2,6 +2,7 @@ package com.todo.todoapp.domain.comment.model;
 
 import com.todo.todoapp.domain.todo.model.Todo;
 import com.todo.todoapp.global.entity.BaseEntity;
+import com.todo.todoapp.presentation.comment.dto.request.UpdateCommentRequest;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -24,4 +25,8 @@ public class Comment extends BaseEntity {
     private String comment;
 
     private String writerId;
+
+    public void update(UpdateCommentRequest request) {
+        this.comment = request.comment();
+    }
 }

--- a/src/main/java/com/todo/todoapp/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/todo/todoapp/domain/comment/repository/CommentRepository.java
@@ -2,6 +2,10 @@ package com.todo.todoapp.domain.comment.repository;
 
 import com.todo.todoapp.domain.comment.model.Comment;
 
+import java.util.Optional;
+
 public interface CommentRepository {
     Comment save(Comment comment);
+
+    Optional<Comment> findById(long id);
 }

--- a/src/main/java/com/todo/todoapp/global/exception/comment/NoSuchCommentException.java
+++ b/src/main/java/com/todo/todoapp/global/exception/comment/NoSuchCommentException.java
@@ -1,0 +1,10 @@
+package com.todo.todoapp.global.exception.comment;
+
+import com.todo.todoapp.global.exception.common.CustomException;
+import com.todo.todoapp.global.exception.common.code.ErrorCode;
+
+public class NoSuchCommentException extends CustomException {
+    public NoSuchCommentException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/exception/comment/code/CommentErrorCode.java
+++ b/src/main/java/com/todo/todoapp/global/exception/comment/code/CommentErrorCode.java
@@ -1,0 +1,36 @@
+package com.todo.todoapp.global.exception.comment.code;
+
+import com.todo.todoapp.global.exception.common.code.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum CommentErrorCode implements ErrorCode {
+    FIND_FAILED(HttpStatus.BAD_REQUEST, "댓글을 찾을 수 없습니다"),
+    ;
+
+    private HttpStatus httpStatus;
+    private String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public void setHttpStatus(HttpStatus httpStatus) {
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/todo/todoapp/infrastructure/comment/CommentRepositoryImpl.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/comment/CommentRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.todo.todoapp.infrastructure.comment.hibernate.CommentJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class CommentRepositoryImpl implements CommentRepository {
@@ -14,5 +16,10 @@ public class CommentRepositoryImpl implements CommentRepository {
     @Override
     public Comment save(Comment comment) {
         return jpaRepository.save(comment);
+    }
+
+    @Override
+    public Optional<Comment> findById(long id) {
+        return jpaRepository.findById(id);
     }
 }

--- a/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
@@ -27,4 +27,12 @@ public class CommentController {
         return ResponseEntity.created(uri).body(response);
     }
 
+    @PatchMapping("/{id}")
+    public ResponseEntity<CommentResponse> update(
+            @PathVariable long id,
+            @Valid @RequestBody UpdateCommentRequest request) {
+        CommentResponse response = commentService.update(id, request);
+
+        return ResponseEntity.ok().body(response);
+    }
 }

--- a/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
@@ -2,6 +2,7 @@ package com.todo.todoapp.presentation.comment;
 
 import com.todo.todoapp.application.comment.CommentService;
 import com.todo.todoapp.presentation.comment.dto.request.CreateCommentRequest;
+import com.todo.todoapp.presentation.comment.dto.request.UpdateCommentRequest;
 import com.todo.todoapp.presentation.comment.dto.response.CommentResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/todo/todoapp/presentation/comment/dto/request/UpdateCommentRequest.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/dto/request/UpdateCommentRequest.java
@@ -1,0 +1,6 @@
+package com.todo.todoapp.presentation.comment.dto.request;
+
+public record UpdateCommentRequest(
+        String comment
+) {
+}


### PR DESCRIPTION
# 관련 이슈
- closes #23 

# 작업
- Controller / Service에 댓글 수정 메서드를 작성하였다.
- Repository에 댓글 단건 조회(id 기반) 및 댓글 수정 메서드를 작성하였다.
- Comment 엔티티 도메인 로직을 작성하였다.
- 댓글 수정을 위한 Request DTO를 생성했다.
