### PR TITLE
Feat: 회원가입 기능 구현

### DIFF
--- a/src/main/java/com/todo/todoapp/application/user/UserService.java
+++ b/src/main/java/com/todo/todoapp/application/user/UserService.java
@@ -18,7 +18,7 @@ public class UserService {
         checkDuplicateNickname(request.nickname());
         User user = userRepository.save(request.toEntity());
 
-        return user.id();
+        return user.getId();
     }
 
     private void checkDuplicateNickname(String nickname) {

--- a/src/main/java/com/todo/todoapp/application/user/UserService.java
+++ b/src/main/java/com/todo/todoapp/application/user/UserService.java
@@ -1,5 +1,6 @@
 package com.todo.todoapp.application.user;
 
+import com.todo.todoapp.domain.user.model.User;
 import com.todo.todoapp.domain.user.repository.UserRepository;
 import com.todo.todoapp.presentation.user.dto.request.SignUpRequest;
 import jakarta.transaction.Transactional;

--- a/src/main/java/com/todo/todoapp/application/user/UserService.java
+++ b/src/main/java/com/todo/todoapp/application/user/UserService.java
@@ -2,6 +2,8 @@ package com.todo.todoapp.application.user;
 
 import com.todo.todoapp.domain.user.model.User;
 import com.todo.todoapp.domain.user.repository.UserRepository;
+import com.todo.todoapp.global.exception.user.DuplicateNicknameException;
+import com.todo.todoapp.global.exception.user.code.UserErrorCode;
 import com.todo.todoapp.presentation.user.dto.request.SignUpRequest;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/todo/todoapp/application/user/UserService.java
+++ b/src/main/java/com/todo/todoapp/application/user/UserService.java
@@ -22,7 +22,7 @@ public class UserService {
     }
 
     private void checkDuplicateNickname(String nickname) {
-        if (userRepository.existByNickname(nickname)) {
+        if (userRepository.existsByNickname(nickname)) {
             throw new DuplicateNicknameException(UserErrorCode.DUPLICATE_NICKNAME);
         }
     }

--- a/src/main/java/com/todo/todoapp/application/user/UserService.java
+++ b/src/main/java/com/todo/todoapp/application/user/UserService.java
@@ -1,0 +1,28 @@
+package com.todo.todoapp.application.user;
+
+import com.todo.todoapp.domain.user.repository.UserRepository;
+import com.todo.todoapp.presentation.user.dto.request.SignUpRequest;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public long signup(SignUpRequest request) {
+        checkDuplicateNickname(request.nickname());
+        User user = userRepository.save(request.toEntity());
+
+        return user.id();
+    }
+
+    private void checkDuplicateNickname(String nickname) {
+        if (userRepository.existByNickname(nickname)) {
+            throw new DuplicateNicknameException(UserErrorCode.DUPLICATE_NICKNAME);
+        }
+    }
+}

--- a/src/main/java/com/todo/todoapp/domain/user/model/User.java
+++ b/src/main/java/com/todo/todoapp/domain/user/model/User.java
@@ -1,0 +1,23 @@
+package com.todo.todoapp.domain.user.model;
+
+import com.todo.todoapp.domain.user.vo.Role;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Getter
+@Builder
+@Entity(name = "users")
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+    private String nickname;
+    private String userName;
+    private String password;
+
+    @Enumerated(EnumType.STRING)
+    private Role userRole;
+}

--- a/src/main/java/com/todo/todoapp/domain/user/model/User.java
+++ b/src/main/java/com/todo/todoapp/domain/user/model/User.java
@@ -12,6 +12,7 @@ import lombok.*;
 public class User {
 
     @Id
+    @Column(name = "user_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
     private String nickname;

--- a/src/main/java/com/todo/todoapp/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/todo/todoapp/domain/user/repository/UserRepository.java
@@ -1,0 +1,9 @@
+package com.todo.todoapp.domain.user.repository;
+
+import com.todo.todoapp.domain.user.model.User;
+
+public interface UserRepository {
+    User save(User user);
+
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/todo/todoapp/domain/user/vo/Role.java
+++ b/src/main/java/com/todo/todoapp/domain/user/vo/Role.java
@@ -1,0 +1,14 @@
+package com.todo.todoapp.domain.user.vo;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Role {
+
+    USER("ROLE_USER"),
+    ADMIN("ROLE_ADMIN"),
+    ;
+    private final String value;
+}

--- a/src/main/java/com/todo/todoapp/global/exception/user/DuplicateNicknameException.java
+++ b/src/main/java/com/todo/todoapp/global/exception/user/DuplicateNicknameException.java
@@ -1,0 +1,10 @@
+package com.todo.todoapp.global.exception.user;
+
+import com.todo.todoapp.global.exception.common.CustomException;
+import com.todo.todoapp.global.exception.common.code.ErrorCode;
+
+public class DuplicateNicknameException extends CustomException {
+    public DuplicateNicknameException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/exception/user/code/UserErrorCode.java
+++ b/src/main/java/com/todo/todoapp/global/exception/user/code/UserErrorCode.java
@@ -1,0 +1,34 @@
+package com.todo.todoapp.global.exception.user.code;
+
+import com.todo.todoapp.global.exception.common.code.ErrorCode;
+import lombok.AllArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@AllArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다.");
+
+    private HttpStatus httpStatus;
+    private String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public void setHttpStatus(HttpStatus httpStatus) {
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/todo/todoapp/infrastructure/user/UserRepositoryImpl.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/user/UserRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.todo.todoapp.infrastructure.user;
+
+import com.todo.todoapp.domain.user.model.User;
+import com.todo.todoapp.domain.user.repository.UserRepository;
+import com.todo.todoapp.infrastructure.user.hibernate.UserJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class UserRepositoryImpl implements UserRepository {
+
+    private final UserJpaRepository jpaRepository;
+
+    @Override
+    public User save(User user) {
+        return jpaRepository.save(user);
+    }
+
+    @Override
+    public boolean existsByNickname(String nickname) {
+        return jpaRepository.existsByNickname(nickname);
+    }
+}

--- a/src/main/java/com/todo/todoapp/infrastructure/user/hibernate/UserJpaRepository.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/user/hibernate/UserJpaRepository.java
@@ -1,0 +1,8 @@
+package com.todo.todoapp.infrastructure.user.hibernate;
+
+import com.todo.todoapp.domain.user.model.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserJpaRepository extends JpaRepository<User, Long> {
+    boolean existsByNickname(String nickname);
+}

--- a/src/main/java/com/todo/todoapp/presentation/user/UserController.java
+++ b/src/main/java/com/todo/todoapp/presentation/user/UserController.java
@@ -1,0 +1,26 @@
+package com.todo.todoapp.presentation.user;
+
+import com.todo.todoapp.presentation.user.dto.request.SignUpRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @PostMapping
+    public ResponseEntity<String> signup(@RequestBody SignUpRequest request) {
+        long id = userService.signup(request);
+        URI uri = URI.create(String.format("/users/%d", id));
+        return ResponseEntity.created(uri).body("회원가입 완료!");
+    }
+}

--- a/src/main/java/com/todo/todoapp/presentation/user/UserController.java
+++ b/src/main/java/com/todo/todoapp/presentation/user/UserController.java
@@ -1,5 +1,6 @@
 package com.todo.todoapp.presentation.user;
 
+import com.todo.todoapp.application.user.UserService;
 import com.todo.todoapp.presentation.user.dto.request.SignUpRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;

--- a/src/main/java/com/todo/todoapp/presentation/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/todo/todoapp/presentation/user/dto/request/SignUpRequest.java
@@ -1,0 +1,17 @@
+package com.todo.todoapp.presentation.user.dto.request;
+
+import com.todo.todoapp.domain.user.vo.Role;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record SignUpRequest(
+        @NotBlank(message = "닉네임을 입력해주세요")
+        String nickname,
+
+        @NotBlank(message = "사용자 이름을 입력해주세요")
+        @Pattern(regexp = "^[a-z0-9]{4,10}$", message = "올바른 양식을 입력해주세요")
+        String userName,
+        String password,
+        Role role
+) {
+}

--- a/src/main/java/com/todo/todoapp/presentation/user/dto/request/SignUpRequest.java
+++ b/src/main/java/com/todo/todoapp/presentation/user/dto/request/SignUpRequest.java
@@ -1,5 +1,6 @@
 package com.todo.todoapp.presentation.user.dto.request;
 
+import com.todo.todoapp.domain.user.model.User;
 import com.todo.todoapp.domain.user.vo.Role;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -14,4 +15,12 @@ public record SignUpRequest(
         String password,
         Role role
 ) {
+    public User toEntity() {
+        return User.builder()
+                .nickname(nickname)
+                .userName(userName)
+                .password(password)
+                .userRole(role)
+                .build();
+    }
 }


### PR DESCRIPTION
# 관련 이슈
- closes #26 

# 작업
- 회원가입에 필요한 Request DTO를 생성하고, 동시에 사용자의 권한을 책임질 값 객체 Role을 생성했다.
  - SignUpRequest에는 추후, 서비스 코드에서 엔티티로 변환시킬 toEntity() 메서드를 포함한다.
- Controller / Service 를 생성하고, 회원가입 로직을 작성했다.
  - Service 비즈니스 로직에는 닉네임 중복 방지 메서드도 추가하였다.
- 닉네임 중복시 발생할 예외 클래스와 관련된 에러코드를 생성하였다.