### PR TITLE
Feat: 로그인 / JWT 인증 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-configuration-processor')
     // SWAGGER
     implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.2.0")
+    // JWT
+    implementation('io.jsonwebtoken:jjwt:0.12.5')
+
     // TEST
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/todo/todoapp/application/user/UserService.java
+++ b/src/main/java/com/todo/todoapp/application/user/UserService.java
@@ -2,6 +2,7 @@ package com.todo.todoapp.application.user;
 
 import com.todo.todoapp.domain.user.model.User;
 import com.todo.todoapp.domain.user.repository.UserRepository;
+import com.todo.todoapp.global.exception.todo.IncorrectPasswordException;
 import com.todo.todoapp.global.exception.user.DuplicateNicknameException;
 import com.todo.todoapp.global.exception.user.NoSuchUserException;
 import com.todo.todoapp.global.exception.user.code.UserErrorCode;
@@ -29,6 +30,10 @@ public class UserService {
     @Transactional
     public AuthenticatedUserResponse verifyUser(LoginRequest loginRequest) {
         User user = getUserByUserName(loginRequest.userName());
+
+        if (!user.getPassword().equals(loginRequest.password())) {
+            throw new IncorrectPasswordException(UserErrorCode.INCORRECT_PASSWORD);
+        }
 
         return AuthenticatedUserResponse.builder()
                 .userName(user.getUserName())

--- a/src/main/java/com/todo/todoapp/application/user/UserService.java
+++ b/src/main/java/com/todo/todoapp/application/user/UserService.java
@@ -12,8 +12,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Set;
-
 @Service
 @RequiredArgsConstructor
 public class UserService {
@@ -34,7 +32,7 @@ public class UserService {
 
         return AuthenticatedUserResponse.builder()
                 .userName(user.getUserName())
-                .roles(Set.of(user.getUserRole()))
+                .role(user.getUserRole())
                 .build();
     }
 

--- a/src/main/java/com/todo/todoapp/application/user/UserService.java
+++ b/src/main/java/com/todo/todoapp/application/user/UserService.java
@@ -3,11 +3,16 @@ package com.todo.todoapp.application.user;
 import com.todo.todoapp.domain.user.model.User;
 import com.todo.todoapp.domain.user.repository.UserRepository;
 import com.todo.todoapp.global.exception.user.DuplicateNicknameException;
+import com.todo.todoapp.global.exception.user.NoSuchUserException;
 import com.todo.todoapp.global.exception.user.code.UserErrorCode;
+import com.todo.todoapp.presentation.user.dto.request.LoginRequest;
 import com.todo.todoapp.presentation.user.dto.request.SignUpRequest;
+import com.todo.todoapp.presentation.user.dto.response.VerifyUserResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.Set;
 
 @Service
 @RequiredArgsConstructor
@@ -23,9 +28,30 @@ public class UserService {
         return user.getId();
     }
 
+    @Transactional
+    public VerifyUserResponse verifyUser(LoginRequest loginRequest) {
+        User user = getUserByUserName(loginRequest.userName());
+
+        return VerifyUserResponse.builder()
+                .userName(user.getUserName())
+                .roles(Set.of(user.getUserRole()))
+                .build();
+    }
+
+    @Transactional
+    public void updateAccessToken(String userName, String accessToken) {
+        User user = getUserByUserName(userName);
+        user.updateAccessToken(accessToken);
+    }
+
+    private User getUserByUserName(String userName) {
+        return userRepository.findByUserName(userName).orElseThrow(() -> new NoSuchUserException(UserErrorCode.FIND_FAILED));
+    }
+
     private void checkDuplicateNickname(String nickname) {
         if (userRepository.existsByNickname(nickname)) {
             throw new DuplicateNicknameException(UserErrorCode.DUPLICATE_NICKNAME);
         }
     }
+
 }

--- a/src/main/java/com/todo/todoapp/application/user/UserService.java
+++ b/src/main/java/com/todo/todoapp/application/user/UserService.java
@@ -7,7 +7,7 @@ import com.todo.todoapp.global.exception.user.NoSuchUserException;
 import com.todo.todoapp.global.exception.user.code.UserErrorCode;
 import com.todo.todoapp.presentation.user.dto.request.LoginRequest;
 import com.todo.todoapp.presentation.user.dto.request.SignUpRequest;
-import com.todo.todoapp.presentation.user.dto.response.VerifyUserResponse;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticatedUserResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -29,10 +29,10 @@ public class UserService {
     }
 
     @Transactional
-    public VerifyUserResponse verifyUser(LoginRequest loginRequest) {
+    public AuthenticatedUserResponse verifyUser(LoginRequest loginRequest) {
         User user = getUserByUserName(loginRequest.userName());
 
-        return VerifyUserResponse.builder()
+        return AuthenticatedUserResponse.builder()
                 .userName(user.getUserName())
                 .roles(Set.of(user.getUserRole()))
                 .build();

--- a/src/main/java/com/todo/todoapp/domain/user/model/User.java
+++ b/src/main/java/com/todo/todoapp/domain/user/model/User.java
@@ -18,7 +18,12 @@ public class User {
     private String nickname;
     private String userName;
     private String password;
+    private String accessToken;
 
     @Enumerated(EnumType.STRING)
     private Role userRole;
+
+    public void updateAccessToken(String accessToken) {
+        this.accessToken = accessToken;
+    }
 }

--- a/src/main/java/com/todo/todoapp/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/todo/todoapp/domain/user/repository/UserRepository.java
@@ -2,8 +2,12 @@ package com.todo.todoapp.domain.user.repository;
 
 import com.todo.todoapp.domain.user.model.User;
 
+import java.util.Optional;
+
 public interface UserRepository {
     User save(User user);
 
     boolean existsByNickname(String nickname);
+
+    Optional<User> findByUserName(String userName);
 }

--- a/src/main/java/com/todo/todoapp/global/auth/JwtAuthorizationFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/JwtAuthorizationFilter.java
@@ -1,0 +1,82 @@
+package com.todo.todoapp.global.auth;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.todo.todoapp.domain.user.vo.Role;
+import com.todo.todoapp.infrastructure.jwt.JwtUtil;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticatedUserResponse;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.util.PatternMatchUtils;
+
+import java.io.IOException;
+
+import static com.todo.todoapp.global.exception.auth.code.AuthErrorCode.*;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class JwtAuthorizationFilter implements Filter {
+
+    private static final String[] whiteUrlList = new String[]{"/users/login", "/users/register", "*/h2-console*"};
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+
+        if (httpServletRequest.getMethod().equals("GET") || checkWhiteList(httpServletRequest.getRequestURI())) {
+            chain.doFilter(request, response);
+            return;
+        }
+
+        if (!containsToken(httpServletRequest)) {
+            httpServletResponse.sendError(AUTHORIZE_FAILED.getHttpStatus().value(), AUTHORIZE_FAILED.getMessage());
+            return;
+        }
+
+        try {
+            String accessToken = httpServletRequest.getHeader("Authorization").substring(7);
+            AuthenticatedUserResponse verifyUser = getAuthenticateUser(accessToken);
+            chain.doFilter(request, response);
+        } catch (JsonParseException e) {
+            log.error("JSON 파싱 실패");
+            httpServletResponse.sendError(HttpServletResponse.SC_BAD_REQUEST, "JSON 파싱 싫패");
+        } catch (MalformedJwtException | UnsupportedJwtException | SignatureException e) {
+            log.error("JWT 인증 실패");
+            httpServletResponse.sendError(JWT_INVALID_FAILED.getHttpStatus().value(), JWT_INVALID_FAILED.getMessage());
+        } catch (ExpiredJwtException e) {
+            log.error("JWT 인증 기한 만료");
+            httpServletResponse.sendError(TOKEN_HAS_EXPIRED.getHttpStatus().value(), TOKEN_HAS_EXPIRED.getMessage());
+        }
+    }
+
+    private AuthenticatedUserResponse getAuthenticateUser(String accessToken) {
+        Claims claims = jwtUtil.getClaims(accessToken);
+        String userName = (String) claims.get("userName");
+        Role role = Role.valueOf((String) claims.get("role"));
+
+        return AuthenticatedUserResponse.builder()
+                .userName(userName)
+                .role(role)
+                .build();
+    }
+
+    private boolean checkWhiteList(String requestURI) {
+        return PatternMatchUtils.simpleMatch(whiteUrlList, requestURI);
+    }
+
+    private boolean containsToken(HttpServletRequest httpServletRequest) {
+        String authorization = httpServletRequest.getHeader("Authorization");
+        return authorization != null && authorization.startsWith("Bearer ");
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/auth/JwtLoginFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/JwtLoginFilter.java
@@ -3,7 +3,7 @@ package com.todo.todoapp.global.auth;
 import com.todo.todoapp.application.user.UserService;
 import com.todo.todoapp.infrastructure.jwt.JwtUtil;
 import com.todo.todoapp.infrastructure.jwt.vo.response.Jwt;
-import com.todo.todoapp.presentation.user.dto.response.VerifyUserResponse;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticatedUserResponse;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -28,12 +28,12 @@ public class JwtLoginFilter implements Filter {
         HttpServletResponse httpServletResponse = (HttpServletResponse) response;
         Object attribute = request.getAttribute(AUTHENTICATE_USER);
 
-        if (attribute instanceof VerifyUserResponse) {
+        if (attribute instanceof AuthenticatedUserResponse) {
             Map<String, Object> claims = new HashMap<>();
-            claims.put("userName", ((VerifyUserResponse) attribute).userName());
-            claims.put("role", ((VerifyUserResponse) attribute).roles());
+            claims.put("userName", ((AuthenticatedUserResponse) attribute).userName());
+            claims.put("role", ((AuthenticatedUserResponse) attribute).roles());
             Jwt jwt = jwtUtil.createJwt(claims);
-            userService.updateAccessToken(((VerifyUserResponse) attribute).userName(), jwt.accessToken());
+            userService.updateAccessToken(((AuthenticatedUserResponse) attribute).userName(), jwt.accessToken());
             httpServletResponse.setHeader("Authorization", "Bearer " + jwt.accessToken());
             return;
         }

--- a/src/main/java/com/todo/todoapp/global/auth/JwtLoginFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/JwtLoginFilter.java
@@ -31,7 +31,7 @@ public class JwtLoginFilter implements Filter {
         if (attribute instanceof AuthenticatedUserResponse) {
             Map<String, Object> claims = new HashMap<>();
             claims.put("userName", ((AuthenticatedUserResponse) attribute).userName());
-            claims.put("role", ((AuthenticatedUserResponse) attribute).roles());
+            claims.put("role", ((AuthenticatedUserResponse) attribute).role());
             Jwt jwt = jwtUtil.createJwt(claims);
             userService.updateAccessToken(((AuthenticatedUserResponse) attribute).userName(), jwt.accessToken());
             httpServletResponse.setHeader("Authorization", "Bearer " + jwt.accessToken());

--- a/src/main/java/com/todo/todoapp/global/auth/JwtLoginFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/JwtLoginFilter.java
@@ -1,0 +1,43 @@
+package com.todo.todoapp.global.auth;
+
+import com.todo.todoapp.application.user.UserService;
+import com.todo.todoapp.infrastructure.jwt.JwtUtil;
+import com.todo.todoapp.infrastructure.jwt.vo.response.Jwt;
+import com.todo.todoapp.presentation.user.dto.response.VerifyUserResponse;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.todo.todoapp.global.auth.VerifyUserFilter.AUTHENTICATE_USER;
+
+@Component
+@RequiredArgsConstructor
+public class JwtLoginFilter implements Filter {
+
+    private final JwtUtil jwtUtil;
+    private final UserService userService;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+        Object attribute = request.getAttribute(AUTHENTICATE_USER);
+
+        if (attribute instanceof VerifyUserResponse) {
+            Map<String, Object> claims = new HashMap<>();
+            claims.put("userName", ((VerifyUserResponse) attribute).userName());
+            claims.put("role", ((VerifyUserResponse) attribute).roles());
+            Jwt jwt = jwtUtil.createJwt(claims);
+            userService.updateAccessToken(((VerifyUserResponse) attribute).userName(), jwt.accessToken());
+            httpServletResponse.setHeader("Authorization", "Bearer " + jwt.accessToken());
+            return;
+        }
+
+        httpServletResponse.sendError(HttpStatus.BAD_REQUEST.value());
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/auth/VerifyUserFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/VerifyUserFilter.java
@@ -1,0 +1,42 @@
+package com.todo.todoapp.global.auth;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todo.todoapp.application.user.UserService;
+import com.todo.todoapp.presentation.user.dto.request.LoginRequest;
+import com.todo.todoapp.presentation.user.dto.response.VerifyUserResponse;
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class VerifyUserFilter implements Filter {
+    public static final String AUTHENTICATE_USER = "authenticateUser";
+    private final ObjectMapper objectMapper;
+    private final UserService userService;
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+
+        if (httpServletRequest.getMethod().equals("POST")) {
+            try {
+                LoginRequest loginRequest = objectMapper.readValue(httpServletRequest.getReader(), LoginRequest.class);
+                VerifyUserResponse verifyUserResponse = userService.verifyUser(loginRequest);
+                request.setAttribute(AUTHENTICATE_USER, verifyUserResponse);
+                chain.doFilter(request, response);
+            } catch (Exception e) {
+                log.error("유저 인증에 실패했습니다");
+                HttpServletResponse httpServletResponse = (HttpServletResponse) response;
+                httpServletResponse.sendError(HttpStatus.BAD_REQUEST.value());
+            }
+        }
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/auth/VerifyUserFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/VerifyUserFilter.java
@@ -3,7 +3,7 @@ package com.todo.todoapp.global.auth;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todo.todoapp.application.user.UserService;
 import com.todo.todoapp.presentation.user.dto.request.LoginRequest;
-import com.todo.todoapp.presentation.user.dto.response.VerifyUserResponse;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticatedUserResponse;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -29,8 +29,8 @@ public class VerifyUserFilter implements Filter {
         if (httpServletRequest.getMethod().equals("POST")) {
             try {
                 LoginRequest loginRequest = objectMapper.readValue(httpServletRequest.getReader(), LoginRequest.class);
-                VerifyUserResponse verifyUserResponse = userService.verifyUser(loginRequest);
-                request.setAttribute(AUTHENTICATE_USER, verifyUserResponse);
+                AuthenticatedUserResponse authenticatedUserResponse = userService.verifyUser(loginRequest);
+                request.setAttribute(AUTHENTICATE_USER, authenticatedUserResponse);
                 chain.doFilter(request, response);
             } catch (Exception e) {
                 log.error("유저 인증에 실패했습니다");

--- a/src/main/java/com/todo/todoapp/global/config/WebConfig.java
+++ b/src/main/java/com/todo/todoapp/global/config/WebConfig.java
@@ -1,0 +1,32 @@
+package com.todo.todoapp.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.todo.todoapp.application.user.UserService;
+import com.todo.todoapp.global.auth.JwtLoginFilter;
+import com.todo.todoapp.global.auth.VerifyUserFilter;
+import com.todo.todoapp.infrastructure.jwt.JwtUtil;
+import jakarta.servlet.Filter;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class WebConfig {
+    @Bean
+    public FilterRegistrationBean verifyUserFilter(ObjectMapper mapper, UserService userService) {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new VerifyUserFilter(mapper, userService));
+        filterRegistrationBean.setOrder(1);
+        filterRegistrationBean.addUrlPatterns("/users/login");
+        return filterRegistrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean jwtLoginFilter(JwtUtil jwtUtil, UserService userService) {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new JwtLoginFilter(jwtUtil, userService));
+        filterRegistrationBean.setOrder(2);
+        filterRegistrationBean.addUrlPatterns("/users/login");
+        return filterRegistrationBean;
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/config/WebConfig.java
+++ b/src/main/java/com/todo/todoapp/global/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.todo.todoapp.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todo.todoapp.application.user.UserService;
+import com.todo.todoapp.global.auth.JwtAuthorizationFilter;
 import com.todo.todoapp.global.auth.JwtLoginFilter;
 import com.todo.todoapp.global.auth.VerifyUserFilter;
 import com.todo.todoapp.infrastructure.jwt.JwtUtil;
@@ -27,6 +28,14 @@ public class WebConfig {
         filterRegistrationBean.setFilter(new JwtLoginFilter(jwtUtil, userService));
         filterRegistrationBean.setOrder(2);
         filterRegistrationBean.addUrlPatterns("/users/login");
+        return filterRegistrationBean;
+    }
+
+    @Bean
+    public FilterRegistrationBean jwtAuthorizationFilter(JwtUtil jwtUtil) {
+        FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
+        filterRegistrationBean.setFilter(new JwtAuthorizationFilter(jwtUtil));
+        filterRegistrationBean.setOrder(2);
         return filterRegistrationBean;
     }
 }

--- a/src/main/java/com/todo/todoapp/global/exception/auth/code/AuthErrorCode.java
+++ b/src/main/java/com/todo/todoapp/global/exception/auth/code/AuthErrorCode.java
@@ -1,0 +1,40 @@
+package com.todo.todoapp.global.exception.auth.code;
+
+import com.todo.todoapp.global.exception.common.code.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum AuthErrorCode implements ErrorCode {
+
+    TOKEN_HAS_EXPIRED(HttpStatus.UNAUTHORIZED, "토큰이 만료되었습니다."),
+    INVALID_TOKEN(HttpStatus.BAD_REQUEST, "토큰이 유효하지 않습니다."),
+    JWT_INVALID_FAILED(HttpStatus.UNAUTHORIZED, "JWT 오류가 발생하였습니다."),
+    AUTHORIZE_FAILED(HttpStatus.UNAUTHORIZED, "인증에 실패하였습니다."),
+
+    ;
+    private HttpStatus httpStatus;
+    private String message;
+
+    @Override
+    public HttpStatus getHttpStatus() {
+        return this.httpStatus;
+    }
+
+    @Override
+    public void setHttpStatus(HttpStatus httpStatus) {
+        this.httpStatus = httpStatus;
+    }
+
+    @Override
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/exception/user/NoSuchUserException.java
+++ b/src/main/java/com/todo/todoapp/global/exception/user/NoSuchUserException.java
@@ -1,0 +1,10 @@
+package com.todo.todoapp.global.exception.user;
+
+import com.todo.todoapp.global.exception.common.CustomException;
+import com.todo.todoapp.global.exception.common.code.ErrorCode;
+
+public class NoSuchUserException extends CustomException {
+    public NoSuchUserException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/exception/user/code/UserErrorCode.java
+++ b/src/main/java/com/todo/todoapp/global/exception/user/code/UserErrorCode.java
@@ -9,8 +9,8 @@ public enum UserErrorCode implements ErrorCode {
 
     DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
     FIND_FAILED(HttpStatus.BAD_REQUEST, "해당 유저는 존재하지 않습니다."),
-    
-    ;
+
+    INCORRECT_PASSWORD(HttpStatus.UNAUTHORIZED, "사용자명 또는 비밀번호가 일치하지 않습니다.");
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/todo/todoapp/global/exception/user/code/UserErrorCode.java
+++ b/src/main/java/com/todo/todoapp/global/exception/user/code/UserErrorCode.java
@@ -7,7 +7,10 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum UserErrorCode implements ErrorCode {
 
-    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다.");
+    DUPLICATE_NICKNAME(HttpStatus.BAD_REQUEST, "이미 사용중인 닉네임입니다."),
+    FIND_FAILED(HttpStatus.BAD_REQUEST, "해당 유저는 존재하지 않습니다."),
+    
+    ;
 
     private HttpStatus httpStatus;
     private String message;

--- a/src/main/java/com/todo/todoapp/global/property/PropertiesConfig.java
+++ b/src/main/java/com/todo/todoapp/global/property/PropertiesConfig.java
@@ -1,0 +1,10 @@
+package com.todo.todoapp.global.property;
+
+import com.todo.todoapp.infrastructure.jwt.config.JwtProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(value = {JwtProperties.class,})
+public class PropertiesConfig {
+}

--- a/src/main/java/com/todo/todoapp/infrastructure/jwt/JwtUtil.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/jwt/JwtUtil.java
@@ -1,0 +1,55 @@
+package com.todo.todoapp.infrastructure.jwt;
+
+import com.todo.todoapp.infrastructure.jwt.config.JwtProperties;
+import com.todo.todoapp.infrastructure.jwt.vo.response.Jwt;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.util.Date;
+import java.util.Map;
+
+@Component
+public class JwtUtil {
+
+    private final JwtProperties jwtProperties;
+    private final Key key;
+
+    public JwtUtil(JwtProperties jwtProperties) {
+        this.jwtProperties = jwtProperties;
+        this.key = Keys.hmacShaKeyFor(jwtProperties.getKey().getBytes());
+    }
+
+    public Jwt createJwt(Map<String, Object> claims) {
+        Date accessTokenExpiredDate = parseDate(jwtProperties.getAccessTokenExpiredDeadLine());
+        String accessToken = createToken(claims, accessTokenExpiredDate);
+
+        return Jwt.builder()
+                .accessToken(accessToken)
+                .build();
+    }
+
+    public String createToken(Map<String, Object> claims, Date accessTokenExpiredDeadLine) {
+        return Jwts.builder()
+                .claims(claims)
+                .expiration(accessTokenExpiredDeadLine)
+                .signWith(key)
+                .compact();
+    }
+
+    public Claims getClaims(String accessToken) {
+        return Jwts.parser()
+                .verifyWith((SecretKey) key)
+                .build()
+                .parseSignedClaims(accessToken)
+                .getPayload();
+    }
+
+    private Date parseDate(String accessTokenExpiredDeadLine) {
+        long expireTimeMils = 1000 * 60 * Long.parseLong(accessTokenExpiredDeadLine); // 60분
+        return new Date(System.currentTimeMillis() + expireTimeMils);
+    }
+}

--- a/src/main/java/com/todo/todoapp/infrastructure/jwt/config/JwtProperties.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/jwt/config/JwtProperties.java
@@ -1,0 +1,14 @@
+package com.todo.todoapp.infrastructure.jwt.config;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@RequiredArgsConstructor
+@ConfigurationProperties(prefix = "jwt")
+public class JwtProperties {
+    private final String issuer;
+    private final String key;
+    private final String accessTokenExpiredDeadLine;
+}

--- a/src/main/java/com/todo/todoapp/infrastructure/jwt/vo/response/Jwt.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/jwt/vo/response/Jwt.java
@@ -1,0 +1,9 @@
+package com.todo.todoapp.infrastructure.jwt.vo.response;
+
+import lombok.Builder;
+
+@Builder
+public record Jwt(
+        String accessToken
+) {
+}

--- a/src/main/java/com/todo/todoapp/infrastructure/user/UserRepositoryImpl.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/user/UserRepositoryImpl.java
@@ -6,6 +6,8 @@ import com.todo.todoapp.infrastructure.user.hibernate.UserJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 @RequiredArgsConstructor
 public class UserRepositoryImpl implements UserRepository {
@@ -20,5 +22,10 @@ public class UserRepositoryImpl implements UserRepository {
     @Override
     public boolean existsByNickname(String nickname) {
         return jpaRepository.existsByNickname(nickname);
+    }
+
+    @Override
+    public Optional<User> findByUserName(String userName) {
+        return jpaRepository.findByUserName(userName);
     }
 }

--- a/src/main/java/com/todo/todoapp/infrastructure/user/hibernate/UserJpaRepository.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/user/hibernate/UserJpaRepository.java
@@ -3,6 +3,10 @@ package com.todo.todoapp.infrastructure.user.hibernate;
 import com.todo.todoapp.domain.user.model.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserJpaRepository extends JpaRepository<User, Long> {
     boolean existsByNickname(String nickname);
+
+    Optional<User> findByUserName(String userName);
 }

--- a/src/main/java/com/todo/todoapp/presentation/user/UserController.java
+++ b/src/main/java/com/todo/todoapp/presentation/user/UserController.java
@@ -18,7 +18,7 @@ public class UserController {
 
     private final UserService userService;
 
-    @PostMapping
+    @PostMapping("/register")
     public ResponseEntity<String> signup(@RequestBody SignUpRequest request) {
         long id = userService.signup(request);
         URI uri = URI.create(String.format("/users/%d", id));

--- a/src/main/java/com/todo/todoapp/presentation/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/todo/todoapp/presentation/user/dto/request/LoginRequest.java
@@ -1,0 +1,7 @@
+package com.todo.todoapp.presentation.user.dto.request;
+
+public record LoginRequest(
+        String userName,
+        String password
+) {
+}

--- a/src/main/java/com/todo/todoapp/presentation/user/dto/response/AuthenticatedUserResponse.java
+++ b/src/main/java/com/todo/todoapp/presentation/user/dto/response/AuthenticatedUserResponse.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import java.util.Set;
 
 @Builder
-public record VerifyUserResponse(
+public record AuthenticatedUserResponse(
         String userName,
         Set<Role> roles
 ) {

--- a/src/main/java/com/todo/todoapp/presentation/user/dto/response/AuthenticatedUserResponse.java
+++ b/src/main/java/com/todo/todoapp/presentation/user/dto/response/AuthenticatedUserResponse.java
@@ -3,11 +3,9 @@ package com.todo.todoapp.presentation.user.dto.response;
 import com.todo.todoapp.domain.user.vo.Role;
 import lombok.Builder;
 
-import java.util.Set;
-
 @Builder
 public record AuthenticatedUserResponse(
         String userName,
-        Set<Role> roles
+        Role role
 ) {
 }

--- a/src/main/java/com/todo/todoapp/presentation/user/dto/response/VerifyUserResponse.java
+++ b/src/main/java/com/todo/todoapp/presentation/user/dto/response/VerifyUserResponse.java
@@ -1,0 +1,13 @@
+package com.todo.todoapp.presentation.user.dto.response;
+
+import com.todo.todoapp.domain.user.vo.Role;
+import lombok.Builder;
+
+import java.util.Set;
+
+@Builder
+public record VerifyUserResponse(
+        String userName,
+        Set<Role> roles
+) {
+}


### PR DESCRIPTION
# 관련 이슈
- closes #25 #27 

# 작업
- 로그인과 JWT 인증을 구현하였다.
- 로그인을 할 때 필터를 통해 인증을 마치면 AccessToken을 헤더에 추가하는 방식으로 구현하였다.

# 로그인 / JWT 발급 플로우
1. 유저는 `users/login`을 통해 로그인을 시도한다.(LoginRequest)
2. Filter에서는 LoginRequest를 통해 User가 존재하는지 확인하고, 유저의 검증(ID, PASSWORD 일치)을 시도한다.
3. 검증을 마치면 AuthenticatedUserResponse를 JwtLoginFilter로 위임한다.
4. JwtLoginFilter에서는 유저의 정보를 통해 JWT를 생성하고 유저의 AccessToken을 업데이트한다.
5. 이후, 유저에게 AccessToken을 헤더로 건네준다.

# 인증 플로우
1. GET 메서드와 H2-Console 등 인증이 불필요한 URI를 제외한 POST, PUT, DELETE 등의 메서드 진입 시, JwtAuthenticationFilter를 타게 된다.
2. JwtAuthenticationFilter에서는 요청 헤더에 토큰이 포함되어 있는지를 확인하고, AccessToken을 통해 인증된 유저인지를 판별한다.
3. 인증된 유저라면 다음 필터에게 작업을 위임한다.

# 고민
- AccessToken을 User 도메인에 함께 포함해야 되는지 많이 고민을 했다.
  - 일단, AccessToken만 사용할 예정이라 포함시키고, 이후에 RefreshToken을 사용하면 따로 저장할까 생각 중이다.
- 인가를 아직 적용하지 않았는데, 이는 커스텀 어노테이션을 활용해서 Spring Security의 AuthenticationPrincipal처럼 사용해 볼 생각이다.