### PR TITLE
Feat: 인가 기능 추가

### DIFF
--- a/src/main/java/com/todo/todoapp/application/comment/CommentService.java
+++ b/src/main/java/com/todo/todoapp/application/comment/CommentService.java
@@ -4,13 +4,19 @@ import com.todo.todoapp.domain.comment.model.Comment;
 import com.todo.todoapp.domain.comment.repository.CommentRepository;
 import com.todo.todoapp.domain.todo.model.Todo;
 import com.todo.todoapp.domain.todo.repository.TodoRepository;
+import com.todo.todoapp.domain.user.model.User;
+import com.todo.todoapp.domain.user.repository.UserRepository;
+import com.todo.todoapp.global.auth.util.AuthUtil;
 import com.todo.todoapp.global.exception.comment.NoSuchCommentException;
 import com.todo.todoapp.global.exception.comment.code.CommentErrorCode;
 import com.todo.todoapp.global.exception.todo.NoSuchTodoException;
 import com.todo.todoapp.global.exception.todo.code.TodoErrorCode;
+import com.todo.todoapp.global.exception.user.NoSuchUserException;
+import com.todo.todoapp.global.exception.user.code.UserErrorCode;
 import com.todo.todoapp.presentation.comment.dto.request.CreateCommentRequest;
 import com.todo.todoapp.presentation.comment.dto.request.UpdateCommentRequest;
 import com.todo.todoapp.presentation.comment.dto.response.CommentResponse;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticateUser;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,36 +25,47 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class CommentService {
 
+    private final UserRepository userRepository;
     private final TodoRepository todoRepository;
     private final CommentRepository commentRepository;
 
     @Transactional
-    public CommentResponse save(long todoId, CreateCommentRequest request) {
+    public CommentResponse save(long todoId, CreateCommentRequest request, AuthenticateUser user) {
         Todo todo = getTodoById(todoId);
-        Comment comment = commentRepository.save(request.toEntity(todo));
+        User currentUser = getUserByUserName(user.userName());
+        Comment comment = commentRepository.save(request.toEntity(todo, currentUser));
 
-        return CommentResponse.from(comment);
+        return CommentResponse.from(comment, currentUser.getUserName());
+    }
+
+
+    @Transactional
+    public CommentResponse update(long id, UpdateCommentRequest request, AuthenticateUser user) {
+        Comment comment = getCommentById(id);
+        User currentUser = getUserByUserName(user.userName());
+        AuthUtil.isAuthorize(comment.getUser(), currentUser);
+        comment.update(request);
+
+        return CommentResponse.from(comment, currentUser.getUserName());
+    }
+
+    @Transactional
+    public void delete(long id, AuthenticateUser user) {
+        Comment comment = getCommentById(id);
+        User currentUser = getUserByUserName(user.userName());
+        AuthUtil.isAuthorize(comment.getUser(), currentUser);
+        commentRepository.delete(comment);
+    }
+
+    private Comment getCommentById(long id) {
+        return commentRepository.findById(id).orElseThrow(() -> new NoSuchCommentException(CommentErrorCode.FIND_FAILED));
     }
 
     private Todo getTodoById(long todoId) {
         return todoRepository.findById(todoId).orElseThrow(() -> new NoSuchTodoException(TodoErrorCode.FIND_FAILED));
     }
 
-    @Transactional
-    public CommentResponse update(long id, UpdateCommentRequest request) {
-        Comment comment = getCommentById(id);
-        comment.update(request);
-        return CommentResponse.from(comment);
-    }
-
-    @Transactional
-    public void delete(long id) {
-        Comment comment = getCommentById(id);
-        commentRepository.delete(comment);
-    }
-
-
-    private Comment getCommentById(long id) {
-        return commentRepository.findById(id).orElseThrow(() -> new NoSuchCommentException(CommentErrorCode.FIND_FAILED));
+    private User getUserByUserName(String userName) {
+        return userRepository.findByUserName(userName).orElseThrow(() -> new NoSuchUserException(UserErrorCode.FIND_FAILED));
     }
 }

--- a/src/main/java/com/todo/todoapp/application/todo/TodoService.java
+++ b/src/main/java/com/todo/todoapp/application/todo/TodoService.java
@@ -2,13 +2,17 @@ package com.todo.todoapp.application.todo;
 
 import com.todo.todoapp.domain.todo.model.Todo;
 import com.todo.todoapp.domain.todo.repository.TodoRepository;
-import com.todo.todoapp.global.exception.todo.IncorrectPasswordException;
+import com.todo.todoapp.domain.user.model.User;
+import com.todo.todoapp.domain.user.repository.UserRepository;
+import com.todo.todoapp.global.auth.util.AuthUtil;
 import com.todo.todoapp.global.exception.todo.NoSuchTodoException;
 import com.todo.todoapp.global.exception.todo.code.TodoErrorCode;
+import com.todo.todoapp.global.exception.user.NoSuchUserException;
+import com.todo.todoapp.global.exception.user.code.UserErrorCode;
 import com.todo.todoapp.presentation.todo.dto.request.CreateTodoRequest;
-import com.todo.todoapp.presentation.todo.dto.request.DeleteTodoRequest;
 import com.todo.todoapp.presentation.todo.dto.request.UpdateTodoRequest;
 import com.todo.todoapp.presentation.todo.dto.response.TodoResponse;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticateUser;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,11 +23,14 @@ import java.util.List;
 @Service
 @RequiredArgsConstructor
 public class TodoService {
+
     private final TodoRepository todoRepository;
+    private final UserRepository userRepository;
 
     @Transactional
-    public TodoResponse save(CreateTodoRequest request) {
-        Todo todo = todoRepository.save(request.toEntity());
+    public TodoResponse save(CreateTodoRequest request, AuthenticateUser authenticateUser) {
+        User currentUser = getUserByUserName(authenticateUser.userName());
+        Todo todo = todoRepository.save(request.toEntity(currentUser));
         return TodoResponse.from(todo);
     }
 
@@ -39,18 +46,22 @@ public class TodoService {
     }
 
     @Transactional
-    public TodoResponse update(long id, UpdateTodoRequest request) {
+    public TodoResponse update(long id, UpdateTodoRequest request, AuthenticateUser authenticateUser) {
         Todo todo = getTodoById(id);
-        isCorrectPassword(todo.getPassword(), request.password());
+        User currentUser = getUserByUserName(authenticateUser.userName());
+        AuthUtil.isAuthorize(todo.getUser(), currentUser);
+
         todo.update(request);
 
         return TodoResponse.from(todo);
     }
 
     @Transactional
-    public void delete(long id, DeleteTodoRequest request) {
+    public void delete(long id, AuthenticateUser authenticateUser) {
         Todo todo = getTodoById(id);
-        isCorrectPassword(todo.getPassword(), request.password());
+        User currentUser = getUserByUserName(authenticateUser.userName());
+        AuthUtil.isAuthorize(todo.getUser(), currentUser);
+
         todoRepository.delete(todo);
     }
 
@@ -58,9 +69,7 @@ public class TodoService {
         return todoRepository.findById(id).orElseThrow(() -> new NoSuchTodoException(TodoErrorCode.FIND_FAILED));
     }
 
-    private void isCorrectPassword(String origin, String comparison) {
-        if (!origin.equals(comparison)) {
-            throw new IncorrectPasswordException(TodoErrorCode.INCORRECT_PASSWORD);
-        }
+    private User getUserByUserName(String userName) {
+        return userRepository.findByUserName(userName).orElseThrow(() -> new NoSuchUserException(UserErrorCode.FIND_FAILED));
     }
 }

--- a/src/main/java/com/todo/todoapp/application/user/UserService.java
+++ b/src/main/java/com/todo/todoapp/application/user/UserService.java
@@ -38,6 +38,7 @@ public class UserService {
         return AuthenticatedUserResponse.builder()
                 .userName(user.getUserName())
                 .role(user.getUserRole())
+                .password(user.getPassword())
                 .build();
     }
 

--- a/src/main/java/com/todo/todoapp/application/user/UserService.java
+++ b/src/main/java/com/todo/todoapp/application/user/UserService.java
@@ -8,7 +8,7 @@ import com.todo.todoapp.global.exception.user.NoSuchUserException;
 import com.todo.todoapp.global.exception.user.code.UserErrorCode;
 import com.todo.todoapp.presentation.user.dto.request.LoginRequest;
 import com.todo.todoapp.presentation.user.dto.request.SignUpRequest;
-import com.todo.todoapp.presentation.user.dto.response.AuthenticatedUserResponse;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticateUser;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -28,14 +28,14 @@ public class UserService {
     }
 
     @Transactional
-    public AuthenticatedUserResponse verifyUser(LoginRequest loginRequest) {
+    public AuthenticateUser verifyUser(LoginRequest loginRequest) {
         User user = getUserByUserName(loginRequest.userName());
 
         if (!user.getPassword().equals(loginRequest.password())) {
             throw new IncorrectPasswordException(UserErrorCode.INCORRECT_PASSWORD);
         }
 
-        return AuthenticatedUserResponse.builder()
+        return AuthenticateUser.builder()
                 .userName(user.getUserName())
                 .role(user.getUserRole())
                 .password(user.getPassword())

--- a/src/main/java/com/todo/todoapp/domain/comment/model/Comment.java
+++ b/src/main/java/com/todo/todoapp/domain/comment/model/Comment.java
@@ -1,6 +1,7 @@
 package com.todo.todoapp.domain.comment.model;
 
 import com.todo.todoapp.domain.todo.model.Todo;
+import com.todo.todoapp.domain.user.model.User;
 import com.todo.todoapp.global.entity.BaseEntity;
 import com.todo.todoapp.presentation.comment.dto.request.UpdateCommentRequest;
 import jakarta.persistence.*;
@@ -22,9 +23,11 @@ public class Comment extends BaseEntity {
     @JoinColumn(name = "todo_id")
     private Todo todo;
 
-    private String comment;
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
 
-    private String writerId;
+    private String comment;
 
     public void update(UpdateCommentRequest request) {
         this.comment = request.comment();

--- a/src/main/java/com/todo/todoapp/domain/todo/model/Todo.java
+++ b/src/main/java/com/todo/todoapp/domain/todo/model/Todo.java
@@ -1,5 +1,6 @@
 package com.todo.todoapp.domain.todo.model;
 
+import com.todo.todoapp.domain.user.model.User;
 import com.todo.todoapp.global.entity.BaseEntity;
 import com.todo.todoapp.presentation.todo.dto.request.UpdateTodoRequest;
 import jakarta.persistence.*;
@@ -20,14 +21,15 @@ public class Todo extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
     private String title;
     private String description;
-    private String manager;
-    private String password;
 
     public void update(UpdateTodoRequest request) {
         this.title = request.title();
         this.description = request.description();
-        this.manager = request.manager();
     }
 }

--- a/src/main/java/com/todo/todoapp/global/auth/annotation/Authenticate.java
+++ b/src/main/java/com/todo/todoapp/global/auth/annotation/Authenticate.java
@@ -1,0 +1,11 @@
+package com.todo.todoapp.global.auth.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER, ElementType.TYPE_PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Authenticate {
+}

--- a/src/main/java/com/todo/todoapp/global/auth/filter/JwtAuthorizationFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/filter/JwtAuthorizationFilter.java
@@ -1,10 +1,8 @@
 package com.todo.todoapp.global.auth.filter;
 
 import com.fasterxml.jackson.core.JsonParseException;
-import com.todo.todoapp.domain.user.vo.Role;
 import com.todo.todoapp.infrastructure.jwt.JwtUtil;
-import com.todo.todoapp.presentation.user.dto.response.AuthenticatedUserResponse;
-import io.jsonwebtoken.Claims;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticateUser;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.UnsupportedJwtException;
@@ -46,7 +44,7 @@ public class JwtAuthorizationFilter implements Filter {
 
         try {
             String accessToken = httpServletRequest.getHeader("Authorization").substring(7);
-            AuthenticatedUserResponse verifyUser = jwtUtil.getAuthenticateUser(accessToken);
+            AuthenticateUser authenticateUser = jwtUtil.getAuthenticateUser(accessToken);
             chain.doFilter(request, response);
         } catch (JsonParseException e) {
             log.error("JSON 파싱 실패");

--- a/src/main/java/com/todo/todoapp/global/auth/filter/JwtLoginFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/filter/JwtLoginFilter.java
@@ -1,4 +1,4 @@
-package com.todo.todoapp.global.auth;
+package com.todo.todoapp.global.auth.filter;
 
 import com.todo.todoapp.application.user.UserService;
 import com.todo.todoapp.infrastructure.jwt.JwtUtil;
@@ -14,7 +14,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import static com.todo.todoapp.global.auth.VerifyUserFilter.AUTHENTICATE_USER;
+import static com.todo.todoapp.global.auth.filter.VerifyUserFilter.AUTHENTICATE_USER;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/com/todo/todoapp/global/auth/filter/JwtLoginFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/filter/JwtLoginFilter.java
@@ -32,6 +32,7 @@ public class JwtLoginFilter implements Filter {
             Map<String, Object> claims = new HashMap<>();
             claims.put("userName", ((AuthenticatedUserResponse) attribute).userName());
             claims.put("role", ((AuthenticatedUserResponse) attribute).role());
+            claims.put("password", ((AuthenticatedUserResponse) attribute).password());
             Jwt jwt = jwtUtil.createJwt(claims);
             userService.updateAccessToken(((AuthenticatedUserResponse) attribute).userName(), jwt.accessToken());
             httpServletResponse.setHeader("Authorization", "Bearer " + jwt.accessToken());

--- a/src/main/java/com/todo/todoapp/global/auth/filter/JwtLoginFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/filter/JwtLoginFilter.java
@@ -36,7 +36,7 @@ public class JwtLoginFilter implements Filter {
             Jwt jwt = jwtUtil.createJwt(claims);
             userService.updateAccessToken(((AuthenticatedUserResponse) attribute).userName(), jwt.accessToken());
             httpServletResponse.setHeader("Authorization", "Bearer " + jwt.accessToken());
-            return;
+            chain.doFilter(request, response);
         }
 
         httpServletResponse.sendError(HttpStatus.BAD_REQUEST.value());

--- a/src/main/java/com/todo/todoapp/global/auth/filter/JwtLoginFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/filter/JwtLoginFilter.java
@@ -3,7 +3,7 @@ package com.todo.todoapp.global.auth.filter;
 import com.todo.todoapp.application.user.UserService;
 import com.todo.todoapp.infrastructure.jwt.JwtUtil;
 import com.todo.todoapp.infrastructure.jwt.vo.response.Jwt;
-import com.todo.todoapp.presentation.user.dto.response.AuthenticatedUserResponse;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticateUser;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -28,13 +28,13 @@ public class JwtLoginFilter implements Filter {
         HttpServletResponse httpServletResponse = (HttpServletResponse) response;
         Object attribute = request.getAttribute(AUTHENTICATE_USER);
 
-        if (attribute instanceof AuthenticatedUserResponse) {
+        if (attribute instanceof AuthenticateUser) {
             Map<String, Object> claims = new HashMap<>();
-            claims.put("userName", ((AuthenticatedUserResponse) attribute).userName());
-            claims.put("role", ((AuthenticatedUserResponse) attribute).role());
-            claims.put("password", ((AuthenticatedUserResponse) attribute).password());
+            claims.put("userName", ((AuthenticateUser) attribute).userName());
+            claims.put("role", ((AuthenticateUser) attribute).role());
+            claims.put("password", ((AuthenticateUser) attribute).password());
             Jwt jwt = jwtUtil.createJwt(claims);
-            userService.updateAccessToken(((AuthenticatedUserResponse) attribute).userName(), jwt.accessToken());
+            userService.updateAccessToken(((AuthenticateUser) attribute).userName(), jwt.accessToken());
             httpServletResponse.setHeader("Authorization", "Bearer " + jwt.accessToken());
             chain.doFilter(request, response);
         }

--- a/src/main/java/com/todo/todoapp/global/auth/filter/VerifyUserFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/filter/VerifyUserFilter.java
@@ -1,4 +1,4 @@
-package com.todo.todoapp.global.auth;
+package com.todo.todoapp.global.auth.filter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todo.todoapp.application.user.UserService;

--- a/src/main/java/com/todo/todoapp/global/auth/filter/VerifyUserFilter.java
+++ b/src/main/java/com/todo/todoapp/global/auth/filter/VerifyUserFilter.java
@@ -3,7 +3,7 @@ package com.todo.todoapp.global.auth.filter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todo.todoapp.application.user.UserService;
 import com.todo.todoapp.presentation.user.dto.request.LoginRequest;
-import com.todo.todoapp.presentation.user.dto.response.AuthenticatedUserResponse;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticateUser;
 import jakarta.servlet.*;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -29,8 +29,8 @@ public class VerifyUserFilter implements Filter {
         if (httpServletRequest.getMethod().equals("POST")) {
             try {
                 LoginRequest loginRequest = objectMapper.readValue(httpServletRequest.getReader(), LoginRequest.class);
-                AuthenticatedUserResponse authenticatedUserResponse = userService.verifyUser(loginRequest);
-                request.setAttribute(AUTHENTICATE_USER, authenticatedUserResponse);
+                AuthenticateUser authenticateUser = userService.verifyUser(loginRequest);
+                request.setAttribute(AUTHENTICATE_USER, authenticateUser);
                 chain.doFilter(request, response);
             } catch (Exception e) {
                 log.error("유저 인증에 실패했습니다");

--- a/src/main/java/com/todo/todoapp/global/auth/resolver/AuthArgumentResolver.java
+++ b/src/main/java/com/todo/todoapp/global/auth/resolver/AuthArgumentResolver.java
@@ -1,0 +1,45 @@
+package com.todo.todoapp.global.auth.resolver;
+
+import com.todo.todoapp.global.auth.annotation.Authenticate;
+import com.todo.todoapp.infrastructure.jwt.JwtUtil;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticatedUserResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import static com.todo.todoapp.infrastructure.jwt.JwtUtil.AUTHORIZATION;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtUtil jwtUtil;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(Authenticate.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) webRequest.getNativeRequest();
+
+        try {
+            String accessToken = httpServletRequest.getHeader(AUTHORIZATION);
+            AuthenticatedUserResponse authenticateUser = jwtUtil.getAuthenticateUser(accessToken.substring(7));
+            httpServletRequest.setAttribute("AuthenticateUser", authenticateUser);
+
+            return authenticateUser;
+        } catch (RuntimeException e) {
+            log.error("AuthenticateArgumentResolver 에러 발생");
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/auth/resolver/AuthArgumentResolver.java
+++ b/src/main/java/com/todo/todoapp/global/auth/resolver/AuthArgumentResolver.java
@@ -2,7 +2,7 @@ package com.todo.todoapp.global.auth.resolver;
 
 import com.todo.todoapp.global.auth.annotation.Authenticate;
 import com.todo.todoapp.infrastructure.jwt.JwtUtil;
-import com.todo.todoapp.presentation.user.dto.response.AuthenticatedUserResponse;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticateUser;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +33,7 @@ public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
 
         try {
             String accessToken = httpServletRequest.getHeader(AUTHORIZATION);
-            AuthenticatedUserResponse authenticateUser = jwtUtil.getAuthenticateUser(accessToken.substring(7));
+            AuthenticateUser authenticateUser = jwtUtil.getAuthenticateUser(accessToken.substring(7));
             httpServletRequest.setAttribute("AuthenticateUser", authenticateUser);
 
             return authenticateUser;

--- a/src/main/java/com/todo/todoapp/global/auth/util/AuthUtil.java
+++ b/src/main/java/com/todo/todoapp/global/auth/util/AuthUtil.java
@@ -1,0 +1,16 @@
+package com.todo.todoapp.global.auth.util;
+
+
+import com.todo.todoapp.domain.user.model.User;
+import com.todo.todoapp.global.exception.auth.UnAuthorizeException;
+import com.todo.todoapp.global.exception.auth.code.AuthErrorCode;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AuthUtil {
+    public static void isAuthorize(User owner, User entered) {
+        if (!owner.getUserName().equals(entered.getUserName())) {
+            throw new UnAuthorizeException(AuthErrorCode.AUTHORIZE_FAILED);
+        }
+    }
+}

--- a/src/main/java/com/todo/todoapp/global/config/WebConfig.java
+++ b/src/main/java/com/todo/todoapp/global/config/WebConfig.java
@@ -2,9 +2,9 @@ package com.todo.todoapp.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.todo.todoapp.application.user.UserService;
-import com.todo.todoapp.global.auth.JwtAuthorizationFilter;
-import com.todo.todoapp.global.auth.JwtLoginFilter;
-import com.todo.todoapp.global.auth.VerifyUserFilter;
+import com.todo.todoapp.global.auth.filter.JwtAuthorizationFilter;
+import com.todo.todoapp.global.auth.filter.JwtLoginFilter;
+import com.todo.todoapp.global.auth.filter.VerifyUserFilter;
 import com.todo.todoapp.infrastructure.jwt.JwtUtil;
 import jakarta.servlet.Filter;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;

--- a/src/main/java/com/todo/todoapp/global/config/WebConfig.java
+++ b/src/main/java/com/todo/todoapp/global/config/WebConfig.java
@@ -5,14 +5,24 @@ import com.todo.todoapp.application.user.UserService;
 import com.todo.todoapp.global.auth.filter.JwtAuthorizationFilter;
 import com.todo.todoapp.global.auth.filter.JwtLoginFilter;
 import com.todo.todoapp.global.auth.filter.VerifyUserFilter;
+import com.todo.todoapp.global.auth.resolver.AuthArgumentResolver;
 import com.todo.todoapp.infrastructure.jwt.JwtUtil;
 import jakarta.servlet.Filter;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 @Configuration
-public class WebConfig {
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthArgumentResolver authArgumentResolver;
+
     @Bean
     public FilterRegistrationBean verifyUserFilter(ObjectMapper mapper, UserService userService) {
         FilterRegistrationBean<Filter> filterRegistrationBean = new FilterRegistrationBean<>();
@@ -37,5 +47,10 @@ public class WebConfig {
         filterRegistrationBean.setFilter(new JwtAuthorizationFilter(jwtUtil));
         filterRegistrationBean.setOrder(2);
         return filterRegistrationBean;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authArgumentResolver);
     }
 }

--- a/src/main/java/com/todo/todoapp/global/exception/auth/UnAuthorizeException.java
+++ b/src/main/java/com/todo/todoapp/global/exception/auth/UnAuthorizeException.java
@@ -1,0 +1,10 @@
+package com.todo.todoapp.global.exception.auth;
+
+import com.todo.todoapp.global.exception.common.CustomException;
+import com.todo.todoapp.global.exception.common.code.ErrorCode;
+
+public class UnAuthorizeException  extends CustomException {
+    public UnAuthorizeException(ErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/todo/todoapp/infrastructure/jwt/JwtUtil.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/jwt/JwtUtil.java
@@ -3,7 +3,7 @@ package com.todo.todoapp.infrastructure.jwt;
 import com.todo.todoapp.domain.user.vo.Role;
 import com.todo.todoapp.infrastructure.jwt.config.JwtProperties;
 import com.todo.todoapp.infrastructure.jwt.vo.response.Jwt;
-import com.todo.todoapp.presentation.user.dto.response.AuthenticatedUserResponse;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticateUser;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
@@ -58,13 +58,13 @@ public class JwtUtil {
         return new Date(System.currentTimeMillis() + expireTimeMils);
     }
 
-    public AuthenticatedUserResponse getAuthenticateUser(String accessToken) {
+    public AuthenticateUser getAuthenticateUser(String accessToken) {
         Claims claims = getClaims(accessToken);
         String userName = (String) claims.get("userName");
         Role role = Role.valueOf((String) claims.get("role"));
         String password = (String) claims.get("password");
 
-        return AuthenticatedUserResponse.builder()
+        return AuthenticateUser.builder()
                 .userName(userName)
                 .role(role)
                 .password(password)

--- a/src/main/java/com/todo/todoapp/infrastructure/jwt/JwtUtil.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/jwt/JwtUtil.java
@@ -62,10 +62,12 @@ public class JwtUtil {
         Claims claims = getClaims(accessToken);
         String userName = (String) claims.get("userName");
         Role role = Role.valueOf((String) claims.get("role"));
+        String password = (String) claims.get("password");
 
         return AuthenticatedUserResponse.builder()
                 .userName(userName)
                 .role(role)
+                .password(password)
                 .build();
     }
 

--- a/src/main/java/com/todo/todoapp/infrastructure/jwt/JwtUtil.java
+++ b/src/main/java/com/todo/todoapp/infrastructure/jwt/JwtUtil.java
@@ -1,10 +1,13 @@
 package com.todo.todoapp.infrastructure.jwt;
 
+import com.todo.todoapp.domain.user.vo.Role;
 import com.todo.todoapp.infrastructure.jwt.config.JwtProperties;
 import com.todo.todoapp.infrastructure.jwt.vo.response.Jwt;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticatedUserResponse;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.stereotype.Component;
 
 import javax.crypto.SecretKey;
@@ -17,6 +20,8 @@ public class JwtUtil {
 
     private final JwtProperties jwtProperties;
     private final Key key;
+
+    public static final String AUTHORIZATION = "Authorization";
 
     public JwtUtil(JwtProperties jwtProperties) {
         this.jwtProperties = jwtProperties;
@@ -51,5 +56,21 @@ public class JwtUtil {
     private Date parseDate(String accessTokenExpiredDeadLine) {
         long expireTimeMils = 1000 * 60 * Long.parseLong(accessTokenExpiredDeadLine); // 60분
         return new Date(System.currentTimeMillis() + expireTimeMils);
+    }
+
+    public AuthenticatedUserResponse getAuthenticateUser(String accessToken) {
+        Claims claims = getClaims(accessToken);
+        String userName = (String) claims.get("userName");
+        Role role = Role.valueOf((String) claims.get("role"));
+
+        return AuthenticatedUserResponse.builder()
+                .userName(userName)
+                .role(role)
+                .build();
+    }
+
+    public boolean containsToken(HttpServletRequest httpServletRequest) {
+        String authorization = httpServletRequest.getHeader(AUTHORIZATION);
+        return authorization != null && authorization.startsWith("Bearer ");
     }
 }

--- a/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
@@ -1,9 +1,11 @@
 package com.todo.todoapp.presentation.comment;
 
 import com.todo.todoapp.application.comment.CommentService;
+import com.todo.todoapp.global.auth.annotation.Authenticate;
 import com.todo.todoapp.presentation.comment.dto.request.CreateCommentRequest;
 import com.todo.todoapp.presentation.comment.dto.request.UpdateCommentRequest;
 import com.todo.todoapp.presentation.comment.dto.response.CommentResponse;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticateUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,9 +23,10 @@ public class CommentController {
     @PostMapping("/{todoId}")
     public ResponseEntity<CommentResponse> save(
             @PathVariable long todoId,
-            @Valid @RequestBody CreateCommentRequest request
+            @Valid @RequestBody CreateCommentRequest request,
+            @Authenticate AuthenticateUser user
     ) {
-        CommentResponse response = commentService.save(todoId, request);
+        CommentResponse response = commentService.save(todoId, request, user);
         long id = response.id();
         URI uri = URI.create(String.format("/comments/%d/%d", todoId, id));
         return ResponseEntity.created(uri).body(response);
@@ -32,15 +35,18 @@ public class CommentController {
     @PatchMapping("/{id}")
     public ResponseEntity<CommentResponse> update(
             @PathVariable long id,
-            @Valid @RequestBody UpdateCommentRequest request) {
-        CommentResponse response = commentService.update(id, request);
+            @Valid @RequestBody UpdateCommentRequest request,
+            @Authenticate AuthenticateUser user) {
+        CommentResponse response = commentService.update(id, request, user);
 
         return ResponseEntity.ok().body(response);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> delete(@PathVariable long id) {
-        commentService.delete(id);
+    public ResponseEntity<Void> delete(
+            @PathVariable long id,
+            @Authenticate AuthenticateUser user) {
+        commentService.delete(id, user);
         return ResponseEntity.noContent().build();
 
     }

--- a/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/CommentController.java
@@ -21,7 +21,8 @@ public class CommentController {
     @PostMapping("/{todoId}")
     public ResponseEntity<CommentResponse> save(
             @PathVariable long todoId,
-            @Valid @RequestBody CreateCommentRequest request) {
+            @Valid @RequestBody CreateCommentRequest request
+    ) {
         CommentResponse response = commentService.save(todoId, request);
         long id = response.id();
         URI uri = URI.create(String.format("/comments/%d/%d", todoId, id));

--- a/src/main/java/com/todo/todoapp/presentation/comment/dto/request/CreateCommentRequest.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/dto/request/CreateCommentRequest.java
@@ -1,21 +1,19 @@
 package com.todo.todoapp.presentation.comment.dto.request;
 
-
 import com.todo.todoapp.domain.comment.model.Comment;
 import com.todo.todoapp.domain.todo.model.Todo;
+import com.todo.todoapp.domain.user.model.User;
 import jakarta.validation.constraints.NotBlank;
 
 public record CreateCommentRequest(
         @NotBlank(message = "내용을 입력해주세요")
-        String comment,
-        @NotBlank(message = "댓글 작성자의 ID를 입력해주세요")
-        String writerId
+        String comment
 ) {
-    public Comment toEntity(Todo todo) {
+    public Comment toEntity(Todo todo, User user) {
         return Comment.builder()
                 .comment(comment)
-                .writerId(writerId)
                 .todo(todo)
+                .user(user)
                 .build();
     }
 }

--- a/src/main/java/com/todo/todoapp/presentation/comment/dto/response/CommentResponse.java
+++ b/src/main/java/com/todo/todoapp/presentation/comment/dto/response/CommentResponse.java
@@ -9,14 +9,14 @@ import java.time.LocalDateTime;
 public record CommentResponse(
         long id,
         String comment,
-        String writerId,
+        String userName,
         LocalDateTime createdAt
 ) {
-    public static CommentResponse from(Comment comment) {
+    public static CommentResponse from(Comment comment, String userName) {
         return CommentResponse.builder()
                 .id(comment.getId())
                 .comment(comment.getComment())
-                .writerId(comment.getWriterId())
+                .userName(userName)
                 .createdAt(comment.getCreatedAt())
                 .build();
 

--- a/src/main/java/com/todo/todoapp/presentation/todo/TodoController.java
+++ b/src/main/java/com/todo/todoapp/presentation/todo/TodoController.java
@@ -1,10 +1,11 @@
 package com.todo.todoapp.presentation.todo;
 
 import com.todo.todoapp.application.todo.TodoService;
+import com.todo.todoapp.global.auth.annotation.Authenticate;
 import com.todo.todoapp.presentation.todo.dto.request.CreateTodoRequest;
-import com.todo.todoapp.presentation.todo.dto.request.DeleteTodoRequest;
 import com.todo.todoapp.presentation.todo.dto.request.UpdateTodoRequest;
 import com.todo.todoapp.presentation.todo.dto.response.TodoResponse;
+import com.todo.todoapp.presentation.user.dto.response.AuthenticateUser;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -21,8 +22,10 @@ public class TodoController {
     private final TodoService todoService;
 
     @PostMapping
-    public ResponseEntity<TodoResponse> save(@Valid @RequestBody CreateTodoRequest request) {
-        TodoResponse response = todoService.save(request);
+    public ResponseEntity<TodoResponse> save(
+            @Valid @RequestBody CreateTodoRequest request,
+            @Authenticate AuthenticateUser authenticateUser) {
+        TodoResponse response = todoService.save(request, authenticateUser);
         long id = response.id();
         URI uri = URI.create(String.format("/todos/%d", id));
         return ResponseEntity.created(uri).body(response);
@@ -43,16 +46,17 @@ public class TodoController {
     @PutMapping("/{id}")
     public ResponseEntity<TodoResponse> update(
             @PathVariable long id,
-            @Valid @RequestBody UpdateTodoRequest request) {
-        TodoResponse response = todoService.update(id, request);
+            @Valid @RequestBody UpdateTodoRequest request,
+            @Authenticate AuthenticateUser authenticateUser) {
+        TodoResponse response = todoService.update(id, request, authenticateUser);
         return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(
             @PathVariable long id,
-            @Valid @RequestBody DeleteTodoRequest request) {
-        todoService.delete(id, request);
+            @Authenticate AuthenticateUser authenticateUser) {
+        todoService.delete(id, authenticateUser);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/todo/todoapp/presentation/todo/dto/request/CreateTodoRequest.java
+++ b/src/main/java/com/todo/todoapp/presentation/todo/dto/request/CreateTodoRequest.java
@@ -1,7 +1,7 @@
 package com.todo.todoapp.presentation.todo.dto.request;
 
 import com.todo.todoapp.domain.todo.model.Todo;
-import jakarta.validation.constraints.Email;
+import com.todo.todoapp.domain.user.model.User;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -12,20 +12,13 @@ public record CreateTodoRequest(
         String title,
         @Size(max = 200)
         @NotBlank(message = "내용을 입력해주세요")
-        String description,
-        @Email(regexp = "[a-z0-9]+@[a-z]+\\.[a-z]{2,3}", message = "올바른 이메일 형식을 입력해주세요")
-        @NotBlank(message = "담당자를 입력해주세요")
-        String manager,
-        @NotBlank(message = "비밀번호는 필수 입력입니다.(4글자)")
-        @Size(min = 4, max = 4)
-        String password
+        String description
 ) {
-    public Todo toEntity() {
+    public Todo toEntity(User user) {
         return Todo.builder()
                 .title(title)
                 .description(description)
-                .manager(manager)
-                .password(password)
+                .user(user)
                 .build();
     }
 }

--- a/src/main/java/com/todo/todoapp/presentation/todo/dto/request/DeleteTodoRequest.java
+++ b/src/main/java/com/todo/todoapp/presentation/todo/dto/request/DeleteTodoRequest.java
@@ -1,9 +1,0 @@
-package com.todo.todoapp.presentation.todo.dto.request;
-
-import jakarta.validation.constraints.NotBlank;
-
-public record DeleteTodoRequest(
-        @NotBlank(message = "비밀번호는 필수 입력입니다")
-        String password
-) {
-}

--- a/src/main/java/com/todo/todoapp/presentation/todo/dto/request/UpdateTodoRequest.java
+++ b/src/main/java/com/todo/todoapp/presentation/todo/dto/request/UpdateTodoRequest.java
@@ -1,6 +1,5 @@
 package com.todo.todoapp.presentation.todo.dto.request;
 
-import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 
@@ -10,12 +9,6 @@ public record UpdateTodoRequest(
         String title,
         @Size(max = 200)
         @NotBlank(message = "수정될 내용을 입력해주세요")
-        String description,
-
-        @Email(regexp = "[a-z0-9]+@[a-z]+\\.[a-z]{2,3}", message = "올바른 이메일 형식을 입력해주세요")
-        @NotBlank(message = "수정될 담당자를 입력해주세요")
-        String manager,
-        @NotBlank(message = "비밀번호는 필수 입력입니다")
-        String password
+        String description
 ) {
 }

--- a/src/main/java/com/todo/todoapp/presentation/todo/dto/response/TodoResponse.java
+++ b/src/main/java/com/todo/todoapp/presentation/todo/dto/response/TodoResponse.java
@@ -11,14 +11,14 @@ public record TodoResponse(
         String title,
         String description,
         LocalDateTime createdAt,
-        String manager
+        String userName
 ) {
     public static TodoResponse from(Todo todo) {
         return TodoResponse.builder()
                 .id(todo.getId())
                 .title(todo.getTitle())
                 .description(todo.getDescription())
-                .manager(todo.getManager())
+                .userName(todo.getUser().getUserName())
                 .createdAt(todo.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/todo/todoapp/presentation/user/dto/response/AuthenticateUser.java
+++ b/src/main/java/com/todo/todoapp/presentation/user/dto/response/AuthenticateUser.java
@@ -4,7 +4,7 @@ import com.todo.todoapp.domain.user.vo.Role;
 import lombok.Builder;
 
 @Builder
-public record AuthenticatedUserResponse(
+public record AuthenticateUser(
         String userName,
         Role role,
         String password

--- a/src/main/java/com/todo/todoapp/presentation/user/dto/response/AuthenticatedUserResponse.java
+++ b/src/main/java/com/todo/todoapp/presentation/user/dto/response/AuthenticatedUserResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 @Builder
 public record AuthenticatedUserResponse(
         String userName,
-        Role role
+        Role role,
+        String password
 ) {
 }


### PR DESCRIPTION
# 관련 이슈
- closes #34 

# 작업
- HandlerMethodArgumentResolver를 구현하여 인증이 완료된 User를 Controller에 건네주고 이후 Service의 비즈니스 로직에서 인가를 처리하게 하였다.

# 고민사항 & 고칠 부분
- AOP로 구현할까 싶었지만, 소규모 프로젝트라서 AuthUtil이라는 클래스를 만들고 그 안에 정적 메서드를 추가하여 인가 처리를 하였다.
- JPA의 연관관계를 정말 필요한 게 아니라면 설정하지 않는다는 친구의 말에 부분 동의하여 리팩토링을 시도할 예정이다.
- IntelliJ의 Inspect Code를 통해 안쓰는 코드나 사용되지 않는 Lombok의 기능들을 제거하거나 수정 할 생각이다.